### PR TITLE
Add USB MIDI Output support

### DIFF
--- a/examples/USBConnection-Basic/USBConnection-Basic.ino
+++ b/examples/USBConnection-Basic/USBConnection-Basic.ino
@@ -1,0 +1,108 @@
+#include <Arduino.h>
+#include <ESP32_Host_MIDI.h>
+
+#define PEDAL_PIN 4
+#define OUT_PIN5 5 // piano detectado
+#define OUT_PIN6 6 // titila
+#define OUT_PIN7 7 // host iniciado
+
+#define FREC_TITILAR 500
+#define FREC_LOOP 10
+
+#define NOTEON_DELAY_MS 200
+#define NOTEOFF_DELAY_MS 300
+#define RESET_TIMEOUT_MS 10000
+
+bool hostIniciado = false;
+bool pianoDetectado = false;
+
+int pedalPresionado = HIGH;
+int pedalAnterior = HIGH;
+
+unsigned long momentoInicioHost = 0;
+unsigned long momentoDeteccion = 0;
+bool noteOnPendiente = false;
+bool noteOffPendiente = false;
+unsigned long momentoNoteOn = 0;
+
+int timerTitilar = 0;
+bool estadoTitilar = false;
+
+void setup() {
+  pinMode(PEDAL_PIN, INPUT_PULLUP);
+  pinMode(OUT_PIN5, OUTPUT);
+  pinMode(OUT_PIN6, OUTPUT);
+  pinMode(OUT_PIN7, OUTPUT);
+
+  digitalWrite(OUT_PIN5, HIGH);
+  digitalWrite(OUT_PIN6, HIGH);
+  digitalWrite(OUT_PIN7, HIGH);
+  delay(1000);
+  digitalWrite(OUT_PIN5, LOW);
+  digitalWrite(OUT_PIN6, LOW);
+  digitalWrite(OUT_PIN7, LOW);
+
+  midiHandler.begin();
+  hostIniciado = true;
+  momentoInicioHost = millis();
+  digitalWrite(OUT_PIN7, HIGH);
+
+  pedalAnterior = digitalRead(PEDAL_PIN);
+}
+
+void loop() {
+  if (timerTitilar >= FREC_TITILAR) {
+    timerTitilar = 0;
+    digitalWrite(OUT_PIN6, estadoTitilar ? LOW : HIGH);
+    estadoTitilar = !estadoTitilar;
+  }
+
+  if (hostIniciado) {
+    midiHandler.task();
+
+    const auto &queue = midiHandler.getQueue();
+
+    if (!queue.empty()) {
+      if (!pianoDetectado) {
+        pianoDetectado = true;
+        momentoDeteccion = millis();
+        noteOnPendiente = true;
+        digitalWrite(OUT_PIN5, HIGH);
+      }
+
+      midiHandler.clearQueue();
+    }
+
+    // Si en 10 segundos no detectó al piano, reiniciar
+    if (!pianoDetectado && (millis() - momentoInicioHost >= RESET_TIMEOUT_MS)) {
+      ESP.restart();
+    }
+
+    if (pianoDetectado && noteOnPendiente && (millis() - momentoDeteccion >= NOTEON_DELAY_MS)) {
+      midiHandler.sendNoteOn(1, 60, 100);
+      momentoNoteOn = millis();
+      noteOnPendiente = false;
+      noteOffPendiente = true;
+    }
+
+    if (pianoDetectado && noteOffPendiente && (millis() - momentoNoteOn >= NOTEOFF_DELAY_MS)) {
+      midiHandler.sendNoteOff(1, 60, 0);
+      noteOffPendiente = false;
+    }
+
+    pedalPresionado = digitalRead(PEDAL_PIN);
+
+    if (pianoDetectado && pedalPresionado != pedalAnterior) {
+      if (pedalPresionado == LOW) {
+        midiHandler.sendControlChange(1, 64, 127);
+      } else {
+        midiHandler.sendControlChange(1, 64, 0);
+      }
+
+      pedalAnterior = pedalPresionado;
+    }
+  }
+
+  timerTitilar += FREC_LOOP;
+  delay(FREC_LOOP);
+}

--- a/src/USBConnection.cpp
+++ b/src/USBConnection.cpp
@@ -16,9 +16,10 @@ USBConnection::USBConnection()
     interval(0),
     lastCheck(0),
     clientHandle(nullptr),
-    deviceHandle(nullptr),
     eventFlags(0),
     midiTransfer(nullptr),
+    _outTransfer(nullptr),
+    _outTransferBusy(false),
     queueHead(0),
     queueTail(0),
     queueMux(portMUX_INITIALIZER_UNLOCKED),
@@ -215,6 +216,10 @@ void USBConnection::_clientEventCallback(const usb_host_client_event_msg_t *even
                 usb_host_transfer_free(usbCon->midiTransfer);
                 usbCon->midiTransfer = nullptr;
             }
+            if (usbCon->_outTransfer) {
+                usb_host_transfer_free(usbCon->_outTransfer);
+                usbCon->_outTransfer = nullptr;
+            }
             usb_host_device_close(usbCon->clientHandle, usbCon->deviceHandle);
             usbCon->isReady = false;
             usbCon->dispatchDisconnected();
@@ -271,7 +276,8 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                         if (len2 < 2 || (idx2 + len2) > totalLength) break;
                         uint8_t type2 = p[idx2 + 1];
                         if (type2 == 0x04) break; // Next interface
-                        if (type2 == 0x05 && bNumEndpoints > 0) {
+                        
+                        if (type2 == 0x05 && bNumEndpoints > 0) { // It's an endpoint descriptor!
                             if (len2 >= 7) {
                                 uint8_t bEndpointAddress = p[idx2 + 2];
                                 uint8_t bmAttributes = p[idx2 + 3];
@@ -279,9 +285,10 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                                 uint8_t bInterval = p[idx2 + 6];
                                 if (wMaxPacketSize > 512) wMaxPacketSize = 512;
                                 if (wMaxPacketSize == 0) wMaxPacketSize = 64;
-                                if (bEndpointAddress & 0x80) {
-                                    uint8_t transferType = bmAttributes & 0x03;
-                                    uint32_t timeout = (transferType == 0x02) ? 3000 : 0;
+                                uint8_t transferType = bmAttributes & 0x03;
+                                uint32_t timeout = (transferType == 0x02) ? 3000 : 0;
+                                
+                                if (bEndpointAddress & 0x80) { // IN Endpoint
                                     esp_err_t e2 = usb_host_transfer_alloc(wMaxPacketSize, timeout, &midiTransfer);
                                     if (e2 == ESP_OK && midiTransfer != nullptr) {
                                         midiTransfer->device_handle = deviceHandle;
@@ -292,13 +299,22 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                                         interval = (bInterval == 0) ? 1 : bInterval;
                                         isReady = true;
                                         claimedOk = true;
-                                        return;
+                                    }
+                                } else { // OUT Endpoint
+                                    esp_err_t e2 = usb_host_transfer_alloc(wMaxPacketSize, timeout, &_outTransfer);
+                                    if (e2 == ESP_OK && _outTransfer != nullptr) {
+                                        _outTransfer->device_handle = deviceHandle;
+                                        _outTransfer->bEndpointAddress = bEndpointAddress;
+                                        _outTransfer->callback = _onSendComplete;
+                                        _outTransfer->context = this;
+                                        _outTransfer->num_bytes = wMaxPacketSize;
                                     }
                                 }
                             }
                         }
                         idx2 += len2;
                     }
+                    if (claimedOk) return;
                     usb_host_interface_release(clientHandle, deviceHandle, bInterfaceNumber);
                 }
             }
@@ -317,5 +333,47 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
             interval = 1;
             isReady = true;
         }
+    }
+}
+
+// ---------- Send ----------
+
+bool USBConnection::sendMidiMessage(const uint8_t* data, size_t length) {
+    if (!isReady || !_outTransfer || length == 0) return false;
+    if (_outTransferBusy) return false;
+
+    // Obtener "Code Index Number" (CIN).
+    // Para NoteOn, NoteOff, CC, y PitchBend el CIN es igual a High Nibble (>> 4).
+    // Para Real-time (status > 0xF8), el CIN es 0x0F.
+    uint8_t cin = 0;
+    if (data[0] >= 0x80 && data[0] <= 0xEF) {
+        cin = data[0] >> 4;
+    } else if (data[0] >= 0xF8) {
+        cin = 0x0F;
+    } else {
+        cin = 0x04; // Para SysEx o mensajes no estándar, aunque SysEx largo requiere partición.
+    }
+
+    uint8_t packet[4] = {0, 0, 0, 0};
+    packet[0] = cin;
+    for (size_t i = 0; i < length && i < 3; i++) {
+        packet[i + 1] = data[i];
+    }
+
+    memcpy(_outTransfer->data_buffer, packet, 4);
+    _outTransfer->num_bytes = 4;
+
+    _outTransferBusy = true;
+    esp_err_t err = usb_host_transfer_submit(_outTransfer);
+    if (err != ESP_OK) {
+        _outTransferBusy = false;
+    }
+    return err == ESP_OK;
+}
+
+void USBConnection::_onSendComplete(usb_transfer_t *transfer) {
+    USBConnection *usbCon = static_cast<USBConnection*>(transfer->context);
+    if (usbCon) {
+        usbCon->_outTransferBusy = false;
     }
 }

--- a/src/USBConnection.h
+++ b/src/USBConnection.h
@@ -29,6 +29,10 @@ public:
     // Returns whether the USB connection is ready.
     bool isConnected() const override { return isReady; }
 
+    // Implementación para enviar mensajes por USB-MIDI
+    bool sendMidiMessage(const uint8_t* data, size_t length) override;
+
+
     // Returns the last error message (empty if none).
     const String& getLastError() const { return lastError; }
 
@@ -44,7 +48,9 @@ protected:
     usb_host_client_handle_t clientHandle;
     usb_device_handle_t deviceHandle;
     uint32_t eventFlags;
-    usb_transfer_t* midiTransfer;
+    usb_transfer_t* midiTransfer;     // Transferencia IN (recepción)
+    usb_transfer_t* _outTransfer;     // Transferencia OUT (envío)
+    volatile bool _outTransferBusy;   // Estado de ocupación del envío
 
     // Ring buffer for raw USB packets.
     // Protected by spinlock for thread-safe access on dual-core ESP32.
@@ -76,6 +82,7 @@ protected:
     // Internal USB Host callbacks.
     static void _clientEventCallback(const usb_host_client_event_msg_t *eventMsg, void *arg);
     static void _onReceive(usb_transfer_t *transfer);
+    static void _onSendComplete(usb_transfer_t *transfer);
     virtual void _processConfig(const usb_config_desc_t *config_desc);
     virtual void _onDeviceGone() {}  // Override to free extra resources on disconnect.
 };


### PR DESCRIPTION
Hi! This PR introduces USB MIDI Output capabilities to the library, allowing the ESP32 acting as a USB Host to send MIDI messages to connected USB MIDI devices (like digital pianos, synthesizers, etc.).
**Key Changes:**
* **Endpoint Allocation:** Modified `_processConfig` in `USBConnection.cpp` to correctly detect the OUT endpoint descriptor and allocate a `usb_transfer_t` for outgoing data.
* **New Send Implementation:** Implemented the `sendMidiMessage()` method inside `USBConnection`. It automatically calculates the correct Code Index Number (CIN) based on the MIDI status byte and properly formats the 4-byte USB-MIDI packet before submitting the transfer.
* **Transfer State Management:** Handled transfer busy states and added an `_onSendComplete` callback to safely allow dispatching subsequent messages.
* **New Example:** Added a new `USBConnection-Basic` sketch in the `examples` folder. It demonstrates a practical use case testing both, incoming data and sending standard MIDI Control Change messages (e.g., simulating a CC64 Sustain pedal).
I hope you find this contribution useful for the project! Let me know if you need any adjustments.