### PR TITLE
Add USB MIDI Output support

### DIFF
--- a/examples/USB-Host-Send-Test/USB-Host-Send-Test.ino
+++ b/examples/USB-Host-Send-Test/USB-Host-Send-Test.ino
@@ -1,0 +1,143 @@
+// USB-Host-Send-Test — ESP32_Host_MIDI integration test
+//
+// Sends every type of standard MIDI message to a connected USB device,
+// reporting pass/fail for each sendMidiMessage() call on Serial.
+// Connect a USB MIDI device (keyboard, synth, interface) and open
+// Serial Monitor at 115200. The test runs once after device detection.
+//
+// Tested message types:
+//   Channel Voice: NoteOn, NoteOff, PolyPressure, CC, ProgramChange,
+//                  ChannelPressure, PitchBend
+//   System Common: MTC Quarter Frame, Song Position, Song Select,
+//                  Tune Request
+//   System Real-Time: Clock, Start, Continue, Stop, Active Sensing,
+//                     System Reset
+//
+// Arduino IDE setup:
+//   Tools > Board    -> ESP32-S3 (T-Display-S3 or DevKit)
+//   Tools > USB Mode -> USB-OTG (TinyUSB)
+
+#include <Arduino.h>
+#include <ESP32_Host_MIDI.h>
+
+static bool testDone = false;
+static int passed = 0;
+static int failed = 0;
+
+// Helper: send raw bytes via the first USB transport and report result.
+static bool sendRaw(const char* label, const uint8_t* data, size_t len) {
+    bool ok = midiHandler.sendRaw(data, len);
+    if (ok) {
+        Serial.printf("  %-40s OK\n", label);
+        passed++;
+    } else {
+        Serial.printf("  %-40s FAIL\n", label);
+        failed++;
+    }
+    delay(5); // small gap between messages
+    return ok;
+}
+
+// Helper: send via MIDIHandler convenience methods.
+static bool sendConvenience(const char* label, bool result) {
+    if (result) {
+        Serial.printf("  %-40s OK\n", label);
+        passed++;
+    } else {
+        Serial.printf("  %-40s FAIL\n", label);
+        failed++;
+    }
+    delay(5);
+    return result;
+}
+
+void runSendTests() {
+    Serial.println("\n=== USB MIDI Send Integration Test ===\n");
+
+    // --- Channel Voice (via convenience API) ---
+    Serial.println("[Channel Voice - Convenience API]");
+    sendConvenience("sendNoteOn  ch1 C4 vel100",
+        midiHandler.sendNoteOn(1, 60, 100));
+    sendConvenience("sendNoteOff ch1 C4",
+        midiHandler.sendNoteOff(1, 60, 0));
+    sendConvenience("sendControlChange ch1 CC64=127",
+        midiHandler.sendControlChange(1, 64, 127));
+    sendConvenience("sendControlChange ch1 CC64=0",
+        midiHandler.sendControlChange(1, 64, 0));
+    sendConvenience("sendProgramChange ch1 prog5",
+        midiHandler.sendProgramChange(1, 5));
+    sendConvenience("sendPitchBend ch1 center",
+        midiHandler.sendPitchBend(1, 0));
+
+    // --- Channel Voice (via raw bytes) ---
+    Serial.println("\n[Channel Voice - Raw Bytes]");
+    { uint8_t d[] = {0x90, 60, 80};  sendRaw("NoteOn  ch1 raw",  d, 3); }
+    { uint8_t d[] = {0x80, 60, 0};   sendRaw("NoteOff ch1 raw",  d, 3); }
+    { uint8_t d[] = {0xA0, 60, 50};  sendRaw("PolyPressure ch1", d, 3); }
+    { uint8_t d[] = {0xB0, 1, 64};   sendRaw("CC ModWheel ch1",  d, 3); }
+    { uint8_t d[] = {0xC0, 10};      sendRaw("ProgramChange ch1",d, 2); }
+    { uint8_t d[] = {0xD0, 80};      sendRaw("ChanPressure ch1", d, 2); }
+    { uint8_t d[] = {0xE0, 0, 0x40}; sendRaw("PitchBend center", d, 3); }
+
+    // All 16 channels NoteOn
+    Serial.println("\n[NoteOn all 16 channels]");
+    for (uint8_t ch = 0; ch < 16; ch++) {
+        char label[40];
+        snprintf(label, sizeof(label), "NoteOn ch%d", ch + 1);
+        uint8_t d[] = { (uint8_t)(0x90 | ch), 60, 100 };
+        sendRaw(label, d, 3);
+    }
+    // NoteOff all 16 channels
+    for (uint8_t ch = 0; ch < 16; ch++) {
+        uint8_t d[] = { (uint8_t)(0x80 | ch), 60, 0 };
+        sendRaw(ch == 0 ? "NoteOff ch1..16 (silent)" : "", d, 3);
+    }
+
+    // --- System Common ---
+    Serial.println("\n[System Common]");
+    { uint8_t d[] = {0xF1, 0x23};       sendRaw("MTC Quarter Frame",     d, 2); }
+    { uint8_t d[] = {0xF2, 0x10, 0x20}; sendRaw("Song Position Pointer", d, 3); }
+    { uint8_t d[] = {0xF3, 0x05};       sendRaw("Song Select",           d, 2); }
+    { uint8_t d[] = {0xF6};             sendRaw("Tune Request",          d, 1); }
+
+    // --- System Real-Time ---
+    Serial.println("\n[System Real-Time]");
+    { uint8_t d[] = {0xF8}; sendRaw("Timing Clock",   d, 1); }
+    { uint8_t d[] = {0xFA}; sendRaw("Start",          d, 1); }
+    { uint8_t d[] = {0xFB}; sendRaw("Continue",       d, 1); }
+    { uint8_t d[] = {0xFC}; sendRaw("Stop",           d, 1); }
+    { uint8_t d[] = {0xFE}; sendRaw("Active Sensing", d, 1); }
+    // Note: 0xFF (System Reset) omitted by default - it resets some devices.
+    // Uncomment to test:
+    // { uint8_t d[] = {0xFF}; sendRaw("System Reset", d, 1); }
+
+    // --- Edge cases ---
+    Serial.println("\n[Edge Cases - Expected Failures]");
+    { uint8_t d[] = {0xF4};  sendRaw("Undefined 0xF4 (expect FAIL)", d, 1); }
+    { uint8_t d[] = {0x3C};  sendRaw("Data byte 0x3C (expect FAIL)", d, 1); }
+
+    Serial.printf("\n=== Results: %d passed, %d failed ===\n\n", passed, failed);
+}
+
+void setup() {
+    Serial.begin(115200);
+    delay(1000);
+    Serial.println("USB-Host-Send-Test: waiting for USB MIDI device...");
+
+    midiHandler.begin();
+}
+
+void loop() {
+    midiHandler.task();
+
+    // Run tests when the USB queue receives any data (device is alive).
+    const auto &queue = midiHandler.getQueue();
+    if (!testDone && !queue.empty()) {
+        midiHandler.clearQueue();
+        delay(200);
+        runSendTests();
+        testDone = true;
+    }
+
+    delay(10);
+}

--- a/examples/USB-Host-Send/USB-Host-Send.ino
+++ b/examples/USB-Host-Send/USB-Host-Send.ino
@@ -1,0 +1,108 @@
+#include <Arduino.h>
+#include <ESP32_Host_MIDI.h>
+
+#define PEDAL_PIN 4
+#define OUT_PIN5 5 // piano detectado
+#define OUT_PIN6 6 // titila
+#define OUT_PIN7 7 // host iniciado
+
+#define FREC_TITILAR 500
+#define FREC_LOOP 10
+
+#define NOTEON_DELAY_MS 200
+#define NOTEOFF_DELAY_MS 300
+#define RESET_TIMEOUT_MS 10000
+
+bool hostIniciado = false;
+bool pianoDetectado = false;
+
+int pedalPresionado = HIGH;
+int pedalAnterior = HIGH;
+
+unsigned long momentoInicioHost = 0;
+unsigned long momentoDeteccion = 0;
+bool noteOnPendiente = false;
+bool noteOffPendiente = false;
+unsigned long momentoNoteOn = 0;
+
+int timerTitilar = 0;
+bool estadoTitilar = false;
+
+void setup() {
+  pinMode(PEDAL_PIN, INPUT_PULLUP);
+  pinMode(OUT_PIN5, OUTPUT);
+  pinMode(OUT_PIN6, OUTPUT);
+  pinMode(OUT_PIN7, OUTPUT);
+
+  digitalWrite(OUT_PIN5, HIGH);
+  digitalWrite(OUT_PIN6, HIGH);
+  digitalWrite(OUT_PIN7, HIGH);
+  delay(1000);
+  digitalWrite(OUT_PIN5, LOW);
+  digitalWrite(OUT_PIN6, LOW);
+  digitalWrite(OUT_PIN7, LOW);
+
+  midiHandler.begin();
+  hostIniciado = true;
+  momentoInicioHost = millis();
+  digitalWrite(OUT_PIN7, HIGH);
+
+  pedalAnterior = digitalRead(PEDAL_PIN);
+}
+
+void loop() {
+  if (timerTitilar >= FREC_TITILAR) {
+    timerTitilar = 0;
+    digitalWrite(OUT_PIN6, estadoTitilar ? LOW : HIGH);
+    estadoTitilar = !estadoTitilar;
+  }
+
+  if (hostIniciado) {
+    midiHandler.task();
+
+    const auto &queue = midiHandler.getQueue();
+
+    if (!queue.empty()) {
+      if (!pianoDetectado) {
+        pianoDetectado = true;
+        momentoDeteccion = millis();
+        noteOnPendiente = true;
+        digitalWrite(OUT_PIN5, HIGH);
+      }
+
+      midiHandler.clearQueue();
+    }
+
+    // Si en 10 segundos no detectó al piano, reiniciar
+    if (!pianoDetectado && (millis() - momentoInicioHost >= RESET_TIMEOUT_MS)) {
+      ESP.restart();
+    }
+
+    if (pianoDetectado && noteOnPendiente && (millis() - momentoDeteccion >= NOTEON_DELAY_MS)) {
+      midiHandler.sendNoteOn(1, 60, 100);
+      momentoNoteOn = millis();
+      noteOnPendiente = false;
+      noteOffPendiente = true;
+    }
+
+    if (pianoDetectado && noteOffPendiente && (millis() - momentoNoteOn >= NOTEOFF_DELAY_MS)) {
+      midiHandler.sendNoteOff(1, 60, 0);
+      noteOffPendiente = false;
+    }
+
+    pedalPresionado = digitalRead(PEDAL_PIN);
+
+    if (pianoDetectado && pedalPresionado != pedalAnterior) {
+      if (pedalPresionado == LOW) {
+        midiHandler.sendControlChange(1, 64, 127);
+      } else {
+        midiHandler.sendControlChange(1, 64, 0);
+      }
+
+      pedalAnterior = pedalPresionado;
+    }
+  }
+
+  timerTitilar += FREC_LOOP;
+  delay(FREC_LOOP);
+}

--- a/extras/tests/test_usb_send.cpp
+++ b/extras/tests/test_usb_send.cpp
@@ -1,0 +1,508 @@
+// ESP32_Host_MIDI — USB MIDI Send unit tests
+// Tests CIN calculation and packet formatting for all MIDI message types.
+// USB-MIDI 1.0 spec Table 4-1.
+//
+// Build:
+//   g++ -std=c++11 -Wall -Wextra -Wno-unused-parameter -o extras/tests/test_usb_send extras/tests/test_usb_send.cpp
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+// ---------------------------------------------------------------------------
+// Minimal test framework (same as test_native.cpp)
+// ---------------------------------------------------------------------------
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define TEST(name) \
+    do { printf("  %-56s", name); } while(0)
+
+#define PASS() \
+    do { printf("OK\n"); ++g_pass; } while(0)
+
+#define FAIL(msg) \
+    do { printf("FAIL  %s\n", msg); ++g_fail; return; } while(0)
+
+#define ASSERT_EQ(a, b) \
+    do { if ((a) != (b)) { \
+        printf("FAIL  expected 0x%02X, got 0x%02X\n", (unsigned)(b), (unsigned)(a)); \
+        ++g_fail; return; } } while(0)
+
+// ---------------------------------------------------------------------------
+// Extract _midiStatusToCIN from USBConnection.cpp (copy for testability)
+// ---------------------------------------------------------------------------
+
+static uint8_t _midiStatusToCIN(uint8_t status) {
+    if (status >= 0x80 && status <= 0xEF) {
+        return status >> 4;
+    }
+    switch (status) {
+        case 0xF0: return 0x04; // SysEx Start
+        case 0xF1: return 0x02; // MTC Quarter Frame (2 bytes)
+        case 0xF2: return 0x03; // Song Position Pointer (3 bytes)
+        case 0xF3: return 0x02; // Song Select (2 bytes)
+        case 0xF6: return 0x05; // Tune Request (1 byte)
+        case 0xF7: return 0x05; // SysEx End (single-byte)
+        case 0xF8: return 0x0F; // Timing Clock
+        case 0xFA: return 0x0F; // Start
+        case 0xFB: return 0x0F; // Continue
+        case 0xFC: return 0x0F; // Stop
+        case 0xFE: return 0x0F; // Active Sensing
+        case 0xFF: return 0x0F; // System Reset
+        default:   return 0;    // Undefined
+    }
+}
+
+// Builds a 4-byte USB-MIDI packet (same logic as USBConnection::sendMidiMessage)
+static bool buildPacket(const uint8_t* data, size_t length, uint8_t* packet) {
+    if (length == 0) return false;
+    uint8_t cin = _midiStatusToCIN(data[0]);
+    if (cin == 0) return false;
+    packet[0] = cin;  // cable 0 | CIN
+    packet[1] = 0;
+    packet[2] = 0;
+    packet[3] = 0;
+    for (size_t i = 0; i < length && i < 3; i++) {
+        packet[i + 1] = data[i];
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// CIN tests: Channel Voice Messages (0x8n - 0xEn)
+// ---------------------------------------------------------------------------
+
+void test_cin_note_off() {
+    TEST("CIN NoteOff (0x8n)");
+    for (uint8_t ch = 0; ch < 16; ch++) {
+        ASSERT_EQ(_midiStatusToCIN(0x80 | ch), 0x08);
+    }
+    PASS();
+}
+
+void test_cin_note_on() {
+    TEST("CIN NoteOn (0x9n)");
+    for (uint8_t ch = 0; ch < 16; ch++) {
+        ASSERT_EQ(_midiStatusToCIN(0x90 | ch), 0x09);
+    }
+    PASS();
+}
+
+void test_cin_poly_pressure() {
+    TEST("CIN PolyPressure (0xAn)");
+    ASSERT_EQ(_midiStatusToCIN(0xA0), 0x0A);
+    ASSERT_EQ(_midiStatusToCIN(0xAF), 0x0A);
+    PASS();
+}
+
+void test_cin_control_change() {
+    TEST("CIN ControlChange (0xBn)");
+    ASSERT_EQ(_midiStatusToCIN(0xB0), 0x0B);
+    ASSERT_EQ(_midiStatusToCIN(0xBF), 0x0B);
+    PASS();
+}
+
+void test_cin_program_change() {
+    TEST("CIN ProgramChange (0xCn)");
+    ASSERT_EQ(_midiStatusToCIN(0xC0), 0x0C);
+    ASSERT_EQ(_midiStatusToCIN(0xCF), 0x0C);
+    PASS();
+}
+
+void test_cin_channel_pressure() {
+    TEST("CIN ChannelPressure (0xDn)");
+    ASSERT_EQ(_midiStatusToCIN(0xD0), 0x0D);
+    ASSERT_EQ(_midiStatusToCIN(0xDF), 0x0D);
+    PASS();
+}
+
+void test_cin_pitch_bend() {
+    TEST("CIN PitchBend (0xEn)");
+    ASSERT_EQ(_midiStatusToCIN(0xE0), 0x0E);
+    ASSERT_EQ(_midiStatusToCIN(0xEF), 0x0E);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// CIN tests: System Common Messages
+// ---------------------------------------------------------------------------
+
+void test_cin_sysex_start() {
+    TEST("CIN SysEx Start (0xF0)");
+    ASSERT_EQ(_midiStatusToCIN(0xF0), 0x04);
+    PASS();
+}
+
+void test_cin_mtc_quarter_frame() {
+    TEST("CIN MTC Quarter Frame (0xF1)");
+    ASSERT_EQ(_midiStatusToCIN(0xF1), 0x02);
+    PASS();
+}
+
+void test_cin_song_position() {
+    TEST("CIN Song Position Pointer (0xF2)");
+    ASSERT_EQ(_midiStatusToCIN(0xF2), 0x03);
+    PASS();
+}
+
+void test_cin_song_select() {
+    TEST("CIN Song Select (0xF3)");
+    ASSERT_EQ(_midiStatusToCIN(0xF3), 0x02);
+    PASS();
+}
+
+void test_cin_tune_request() {
+    TEST("CIN Tune Request (0xF6)");
+    ASSERT_EQ(_midiStatusToCIN(0xF6), 0x05);
+    PASS();
+}
+
+void test_cin_sysex_end() {
+    TEST("CIN SysEx End (0xF7)");
+    ASSERT_EQ(_midiStatusToCIN(0xF7), 0x05);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// CIN tests: System Real-Time Messages
+// ---------------------------------------------------------------------------
+
+void test_cin_timing_clock() {
+    TEST("CIN Timing Clock (0xF8)");
+    ASSERT_EQ(_midiStatusToCIN(0xF8), 0x0F);
+    PASS();
+}
+
+void test_cin_start() {
+    TEST("CIN Start (0xFA)");
+    ASSERT_EQ(_midiStatusToCIN(0xFA), 0x0F);
+    PASS();
+}
+
+void test_cin_continue() {
+    TEST("CIN Continue (0xFB)");
+    ASSERT_EQ(_midiStatusToCIN(0xFB), 0x0F);
+    PASS();
+}
+
+void test_cin_stop() {
+    TEST("CIN Stop (0xFC)");
+    ASSERT_EQ(_midiStatusToCIN(0xFC), 0x0F);
+    PASS();
+}
+
+void test_cin_active_sensing() {
+    TEST("CIN Active Sensing (0xFE)");
+    ASSERT_EQ(_midiStatusToCIN(0xFE), 0x0F);
+    PASS();
+}
+
+void test_cin_system_reset() {
+    TEST("CIN System Reset (0xFF)");
+    ASSERT_EQ(_midiStatusToCIN(0xFF), 0x0F);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// CIN tests: Undefined status bytes
+// ---------------------------------------------------------------------------
+
+void test_cin_undefined() {
+    TEST("CIN undefined (0xF4, 0xF5, 0xFD)");
+    ASSERT_EQ(_midiStatusToCIN(0xF4), 0x00);
+    ASSERT_EQ(_midiStatusToCIN(0xF5), 0x00);
+    ASSERT_EQ(_midiStatusToCIN(0xFD), 0x00);
+    PASS();
+}
+
+void test_cin_not_status() {
+    TEST("CIN rejects data bytes (0x00-0x7F)");
+    ASSERT_EQ(_midiStatusToCIN(0x00), 0x00);
+    ASSERT_EQ(_midiStatusToCIN(0x3C), 0x00);
+    ASSERT_EQ(_midiStatusToCIN(0x7F), 0x00);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Packet formatting tests
+// ---------------------------------------------------------------------------
+
+void test_packet_note_on() {
+    TEST("Packet NoteOn ch1 C4 vel100");
+    uint8_t data[] = { 0x90, 60, 100 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 3, pkt), true);
+    ASSERT_EQ(pkt[0], 0x09);  // CIN
+    ASSERT_EQ(pkt[1], 0x90);  // status
+    ASSERT_EQ(pkt[2], 60);    // note
+    ASSERT_EQ(pkt[3], 100);   // velocity
+    PASS();
+}
+
+void test_packet_note_off() {
+    TEST("Packet NoteOff ch1 C4");
+    uint8_t data[] = { 0x80, 60, 0 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 3, pkt), true);
+    ASSERT_EQ(pkt[0], 0x08);
+    ASSERT_EQ(pkt[1], 0x80);
+    ASSERT_EQ(pkt[2], 60);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_cc() {
+    TEST("Packet CC ch1 sustain on");
+    uint8_t data[] = { 0xB0, 64, 127 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 3, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0B);
+    ASSERT_EQ(pkt[1], 0xB0);
+    ASSERT_EQ(pkt[2], 64);
+    ASSERT_EQ(pkt[3], 127);
+    PASS();
+}
+
+void test_packet_program_change() {
+    TEST("Packet ProgramChange ch1 prog5 (2 bytes)");
+    uint8_t data[] = { 0xC0, 5 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 2, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0C);
+    ASSERT_EQ(pkt[1], 0xC0);
+    ASSERT_EQ(pkt[2], 5);
+    ASSERT_EQ(pkt[3], 0);    // padded with zero
+    PASS();
+}
+
+void test_packet_channel_pressure() {
+    TEST("Packet ChannelPressure ch1 (2 bytes)");
+    uint8_t data[] = { 0xD0, 100 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 2, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0D);
+    ASSERT_EQ(pkt[1], 0xD0);
+    ASSERT_EQ(pkt[2], 100);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_pitch_bend() {
+    TEST("Packet PitchBend ch1 center");
+    uint8_t data[] = { 0xE0, 0x00, 0x40 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 3, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0E);
+    ASSERT_EQ(pkt[1], 0xE0);
+    ASSERT_EQ(pkt[2], 0x00);
+    ASSERT_EQ(pkt[3], 0x40);
+    PASS();
+}
+
+void test_packet_mtc_quarter_frame() {
+    TEST("Packet MTC Quarter Frame (2 bytes)");
+    uint8_t data[] = { 0xF1, 0x23 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 2, pkt), true);
+    ASSERT_EQ(pkt[0], 0x02);
+    ASSERT_EQ(pkt[1], 0xF1);
+    ASSERT_EQ(pkt[2], 0x23);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_song_position() {
+    TEST("Packet Song Position Pointer (3 bytes)");
+    uint8_t data[] = { 0xF2, 0x10, 0x20 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 3, pkt), true);
+    ASSERT_EQ(pkt[0], 0x03);
+    ASSERT_EQ(pkt[1], 0xF2);
+    ASSERT_EQ(pkt[2], 0x10);
+    ASSERT_EQ(pkt[3], 0x20);
+    PASS();
+}
+
+void test_packet_song_select() {
+    TEST("Packet Song Select (2 bytes)");
+    uint8_t data[] = { 0xF3, 0x05 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 2, pkt), true);
+    ASSERT_EQ(pkt[0], 0x02);
+    ASSERT_EQ(pkt[1], 0xF3);
+    ASSERT_EQ(pkt[2], 0x05);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_tune_request() {
+    TEST("Packet Tune Request (1 byte)");
+    uint8_t data[] = { 0xF6 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x05);
+    ASSERT_EQ(pkt[1], 0xF6);
+    ASSERT_EQ(pkt[2], 0);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_realtime_clock() {
+    TEST("Packet Timing Clock (1 byte)");
+    uint8_t data[] = { 0xF8 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0F);
+    ASSERT_EQ(pkt[1], 0xF8);
+    ASSERT_EQ(pkt[2], 0);
+    ASSERT_EQ(pkt[3], 0);
+    PASS();
+}
+
+void test_packet_realtime_start() {
+    TEST("Packet Start (1 byte)");
+    uint8_t data[] = { 0xFA };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0F);
+    ASSERT_EQ(pkt[1], 0xFA);
+    PASS();
+}
+
+void test_packet_realtime_stop() {
+    TEST("Packet Stop (1 byte)");
+    uint8_t data[] = { 0xFC };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0F);
+    ASSERT_EQ(pkt[1], 0xFC);
+    PASS();
+}
+
+void test_packet_active_sensing() {
+    TEST("Packet Active Sensing (1 byte)");
+    uint8_t data[] = { 0xFE };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0F);
+    ASSERT_EQ(pkt[1], 0xFE);
+    PASS();
+}
+
+void test_packet_system_reset() {
+    TEST("Packet System Reset (1 byte)");
+    uint8_t data[] = { 0xFF };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), true);
+    ASSERT_EQ(pkt[0], 0x0F);
+    ASSERT_EQ(pkt[1], 0xFF);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+void test_packet_rejects_undefined() {
+    TEST("Packet rejects undefined status 0xF4");
+    uint8_t data[] = { 0xF4 };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), false);
+    PASS();
+}
+
+void test_packet_rejects_data_byte() {
+    TEST("Packet rejects data byte 0x3C");
+    uint8_t data[] = { 0x3C };
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(data, 1, pkt), false);
+    PASS();
+}
+
+void test_packet_rejects_zero_length() {
+    TEST("Packet rejects zero length");
+    uint8_t pkt[4];
+    ASSERT_EQ(buildPacket(nullptr, 0, pkt), false);
+    PASS();
+}
+
+void test_packet_all_channels_note_on() {
+    TEST("Packet NoteOn all 16 channels");
+    uint8_t pkt[4];
+    for (uint8_t ch = 0; ch < 16; ch++) {
+        uint8_t data[] = { (uint8_t)(0x90 | ch), 60, 100 };
+        ASSERT_EQ(buildPacket(data, 3, pkt), true);
+        ASSERT_EQ(pkt[0], 0x09);
+        ASSERT_EQ(pkt[1], (uint8_t)(0x90 | ch));
+    }
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+int main() {
+    printf("=== USB MIDI Send Tests ===\n\n");
+
+    printf("[CIN: Channel Voice]\n");
+    test_cin_note_off();
+    test_cin_note_on();
+    test_cin_poly_pressure();
+    test_cin_control_change();
+    test_cin_program_change();
+    test_cin_channel_pressure();
+    test_cin_pitch_bend();
+
+    printf("\n[CIN: System Common]\n");
+    test_cin_sysex_start();
+    test_cin_mtc_quarter_frame();
+    test_cin_song_position();
+    test_cin_song_select();
+    test_cin_tune_request();
+    test_cin_sysex_end();
+
+    printf("\n[CIN: System Real-Time]\n");
+    test_cin_timing_clock();
+    test_cin_start();
+    test_cin_continue();
+    test_cin_stop();
+    test_cin_active_sensing();
+    test_cin_system_reset();
+
+    printf("\n[CIN: Edge Cases]\n");
+    test_cin_undefined();
+    test_cin_not_status();
+
+    printf("\n[Packet: Channel Voice]\n");
+    test_packet_note_on();
+    test_packet_note_off();
+    test_packet_cc();
+    test_packet_program_change();
+    test_packet_channel_pressure();
+    test_packet_pitch_bend();
+
+    printf("\n[Packet: System Common]\n");
+    test_packet_mtc_quarter_frame();
+    test_packet_song_position();
+    test_packet_song_select();
+    test_packet_tune_request();
+
+    printf("\n[Packet: System Real-Time]\n");
+    test_packet_realtime_clock();
+    test_packet_realtime_start();
+    test_packet_realtime_stop();
+    test_packet_active_sensing();
+    test_packet_system_reset();
+
+    printf("\n[Edge Cases]\n");
+    test_packet_rejects_undefined();
+    test_packet_rejects_data_byte();
+    test_packet_rejects_zero_length();
+    test_packet_all_channels_note_on();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/src/USBConnection.cpp
+++ b/src/USBConnection.cpp
@@ -19,6 +19,8 @@ USBConnection::USBConnection()
     deviceHandle(nullptr),
     eventFlags(0),
     midiTransfer(nullptr),
+    _outTransfer(nullptr),
+    _outTransferBusy(false),
     queueHead(0),
     queueTail(0),
     queueMux(portMUX_INITIALIZER_UNLOCKED),
@@ -215,6 +217,10 @@ void USBConnection::_clientEventCallback(const usb_host_client_event_msg_t *even
                 usb_host_transfer_free(usbCon->midiTransfer);
                 usbCon->midiTransfer = nullptr;
             }
+            if (usbCon->_outTransfer) {
+                usb_host_transfer_free(usbCon->_outTransfer);
+                usbCon->_outTransfer = nullptr;
+            }
             usb_host_device_close(usbCon->clientHandle, usbCon->deviceHandle);
             usbCon->isReady = false;
             usbCon->dispatchDisconnected();
@@ -271,7 +277,8 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                         if (len2 < 2 || (idx2 + len2) > totalLength) break;
                         uint8_t type2 = p[idx2 + 1];
                         if (type2 == 0x04) break; // Next interface
-                        if (type2 == 0x05 && bNumEndpoints > 0) {
+                        
+                        if (type2 == 0x05 && bNumEndpoints > 0) { // It's an endpoint descriptor!
                             if (len2 >= 7) {
                                 uint8_t bEndpointAddress = p[idx2 + 2];
                                 uint8_t bmAttributes = p[idx2 + 3];
@@ -279,9 +286,10 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                                 uint8_t bInterval = p[idx2 + 6];
                                 if (wMaxPacketSize > 512) wMaxPacketSize = 512;
                                 if (wMaxPacketSize == 0) wMaxPacketSize = 64;
-                                if (bEndpointAddress & 0x80) {
-                                    uint8_t transferType = bmAttributes & 0x03;
-                                    uint32_t timeout = (transferType == 0x02) ? 3000 : 0;
+                                uint8_t transferType = bmAttributes & 0x03;
+                                uint32_t timeout = (transferType == 0x02) ? 3000 : 0;
+                                
+                                if (bEndpointAddress & 0x80) { // IN Endpoint
                                     esp_err_t e2 = usb_host_transfer_alloc(wMaxPacketSize, timeout, &midiTransfer);
                                     if (e2 == ESP_OK && midiTransfer != nullptr) {
                                         midiTransfer->device_handle = deviceHandle;
@@ -292,13 +300,22 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
                                         interval = (bInterval == 0) ? 1 : bInterval;
                                         isReady = true;
                                         claimedOk = true;
-                                        return;
+                                    }
+                                } else { // OUT Endpoint
+                                    esp_err_t e2 = usb_host_transfer_alloc(wMaxPacketSize, timeout, &_outTransfer);
+                                    if (e2 == ESP_OK && _outTransfer != nullptr) {
+                                        _outTransfer->device_handle = deviceHandle;
+                                        _outTransfer->bEndpointAddress = bEndpointAddress;
+                                        _outTransfer->callback = _onSendComplete;
+                                        _outTransfer->context = this;
+                                        _outTransfer->num_bytes = wMaxPacketSize;
                                     }
                                 }
                             }
                         }
                         idx2 += len2;
                     }
+                    if (claimedOk) return;
                     usb_host_interface_release(clientHandle, deviceHandle, bInterfaceNumber);
                 }
             }
@@ -317,5 +334,62 @@ void USBConnection::_processConfig(const usb_config_desc_t *config_desc) {
             interval = 1;
             isReady = true;
         }
+    }
+}
+
+// ---------- Send ----------
+
+// USB-MIDI 1.0 CIN lookup (Table 4-1).
+// Returns CIN for a given MIDI status byte, or 0 on unknown.
+static uint8_t _midiStatusToCIN(uint8_t status) {
+    if (status >= 0x80 && status <= 0xEF) {
+        // Channel Voice / Mode messages: CIN = high nibble
+        return status >> 4;
+    }
+    switch (status) {
+        case 0xF0: return 0x04; // SysEx Start (caller must handle continuation/end)
+        case 0xF1: return 0x02; // MTC Quarter Frame (2 bytes)
+        case 0xF2: return 0x03; // Song Position Pointer (3 bytes)
+        case 0xF3: return 0x02; // Song Select (2 bytes)
+        case 0xF6: return 0x05; // Tune Request (1 byte)
+        case 0xF7: return 0x05; // SysEx End (single-byte, edge case)
+        case 0xF8: return 0x0F; // Timing Clock
+        case 0xFA: return 0x0F; // Start
+        case 0xFB: return 0x0F; // Continue
+        case 0xFC: return 0x0F; // Stop
+        case 0xFE: return 0x0F; // Active Sensing
+        case 0xFF: return 0x0F; // System Reset
+        default:   return 0;    // Undefined (0xF4, 0xF5, 0xFD)
+    }
+}
+
+bool USBConnection::sendMidiMessage(const uint8_t* data, size_t length) {
+    if (!isReady || !_outTransfer || length == 0) return false;
+    if (_outTransferBusy) return false;
+
+    uint8_t cin = _midiStatusToCIN(data[0]);
+    if (cin == 0) return false;
+
+    // Cable number 0 | CIN
+    uint8_t packet[4] = { cin, 0, 0, 0 };
+    for (size_t i = 0; i < length && i < 3; i++) {
+        packet[i + 1] = data[i];
+    }
+
+    memcpy(_outTransfer->data_buffer, packet, 4);
+    _outTransfer->num_bytes = 4;
+
+    _outTransferBusy = true;
+    esp_err_t err = usb_host_transfer_submit(_outTransfer);
+    if (err != ESP_OK) {
+        _outTransferBusy = false;
+    }
+    return err == ESP_OK;
+}
+
+void USBConnection::_onSendComplete(usb_transfer_t *transfer) {
+    USBConnection *usbCon = static_cast<USBConnection*>(transfer->context);
+    if (usbCon) {
+        usbCon->_outTransferBusy = false;
     }
 }

--- a/src/USBConnection.h
+++ b/src/USBConnection.h
@@ -29,6 +29,9 @@ public:
     // Returns whether the USB connection is ready.
     bool isConnected() const override { return isReady; }
 
+    // Sends a MIDI message to the connected USB device.
+    bool sendMidiMessage(const uint8_t* data, size_t length) override;
+
     // Returns the last error message (empty if none).
     const String& getLastError() const { return lastError; }
 
@@ -44,7 +47,9 @@ protected:
     usb_host_client_handle_t clientHandle;
     usb_device_handle_t deviceHandle;
     uint32_t eventFlags;
-    usb_transfer_t* midiTransfer;
+    usb_transfer_t* midiTransfer;     // IN transfer (receive)
+    usb_transfer_t* _outTransfer;     // OUT transfer (send)
+    volatile bool _outTransferBusy;   // True while an OUT transfer is pending
 
     // Ring buffer for raw USB packets.
     // Protected by spinlock for thread-safe access on dual-core ESP32.
@@ -76,6 +81,7 @@ protected:
     // Internal USB Host callbacks.
     static void _clientEventCallback(const usb_host_client_event_msg_t *eventMsg, void *arg);
     static void _onReceive(usb_transfer_t *transfer);
+    static void _onSendComplete(usb_transfer_t *transfer);
     virtual void _processConfig(const usb_config_desc_t *config_desc);
     virtual void _onDeviceGone() {}  // Override to free extra resources on disconnect.
 };


### PR DESCRIPTION
## Summary

Implements `sendMidiMessage()` for `USBConnection`, which was the only transport without send capability. The ESP32 acting as USB Host can now send MIDI messages to connected USB devices (keyboards, synths, interfaces).

Based on the work by @gabalfonso in #19, with the following improvements:

**Bug fixes:**
- Restore `deviceHandle(nullptr)` in constructor initializer list (was left uninitialized)
- Fix CIN (Code Index Number) for System Common messages (0xF1-0xF7) per USB-MIDI 1.0 Table 4-1
- The original code used CIN 0x04 (SysEx) as fallback for all System Common/Real-Time, which is incorrect

**Implementation:**
- OUT endpoint detection during USB config descriptor parsing
- `_midiStatusToCIN()` lookup covering all 22 defined MIDI status bytes
- Transfer state management with `_onSendComplete` callback
- Proper cleanup on device disconnect

**Tests:**
- 40 unit tests (CIN calculation + packet formatting for every MIDI message type)
- `USB-Host-Send-Test` example: integration test that validates all message types on real hardware

**Examples:**
- `USB-Host-Send`: practical example sending NoteOn/NoteOff/CC to a connected USB device (pedal demo, based on @gabalfonso original)

## Limitations (documented, acceptable for v1)
- SysEx send not supported (fragmented SysEx requires multi-packet handling)
- Cable number fixed at 0 (works for single-cable devices, which is 99% of USB MIDI hardware)
- No retry on busy (returns false, caller responsible)

## Test plan
- [x] 40 unit tests pass (`g++ -std=c++11`, zero warnings)
- [ ] Integration test on ESP32-S3 with USB MIDI device connected
- [ ] Verify NoteOn/NoteOff audible on connected synth
- [ ] Verify CC64 (Sustain) toggles correctly
- [ ] Confirm System Common messages (MTC, Song Position) arrive at device

Ref #19

Co-Authored-By: Gabriel Alfonso <gabriel.alfonso@smg.com.ar>