### PR TITLE
fix: remove deprecated BLE2902 manual descriptor

### DIFF
--- a/src/BLEConnection.cpp
+++ b/src/BLEConnection.cpp
@@ -54,15 +54,16 @@ void BLEConnection::begin(const std::string& deviceName) {
 
     BLEService* pService = pServer->createService(BLE_MIDI_SERVICE_UUID);
 
-    // BLE MIDI spec requires READ + NOTIFY + WRITE_NR
+    // BLE MIDI spec requires READ + NOTIFY + WRITE_NR.
+    // The CCCD (0x2902) descriptor is added automatically by the underlying stack
+    // (NimBLE in arduino-esp32 3.x; BlueDroid in 2.x) whenever NOTIFY/INDICATE is set,
+    // so we no longer add it manually (BLE2902 is deprecated and will be removed).
     pCharacteristic = pService->createCharacteristic(
         BLE_MIDI_CHARACTERISTIC_UUID,
         BLECharacteristic::PROPERTY_READ    |
         BLECharacteristic::PROPERTY_NOTIFY  |
         BLECharacteristic::PROPERTY_WRITE_NR
     );
-    // CCCD descriptor: allows the central to enable/disable notifications.
-    pCharacteristic->addDescriptor(new BLE2902());
 
     // Receive callback: strips the 2-byte BLE MIDI header and enqueues raw MIDI bytes.
     // BLE MIDI packet format: [header][timestamp][midi_bytes...]

--- a/src/BLEConnection.h
+++ b/src/BLEConnection.h
@@ -4,7 +4,6 @@
 #include <Arduino.h>
 #include <BLEDevice.h>
 #include <BLEServer.h>
-#include <BLE2902.h>
 #include <freertos/portmacro.h>
 #include <freertos/semphr.h>
 #include "MIDITransport.h"


### PR DESCRIPTION
## Summary

- Drops the manual `addDescriptor(new BLE2902())` call in `BLEConnection`.
- Removes the now-unused `<BLE2902.h>` include.

## Why

Starting with arduino-esp32 3.x the BLE stack moved to NimBLE, which automatically creates the 0x2902 CCCD descriptor whenever a characteristic has `NOTIFY` or `INDICATE` enabled. The `BLE2902` class is therefore flagged `[[deprecated]]` and will be removed in a future release. BlueDroid (2.x) also exposes the CCCD automatically when `NOTIFY` is set, so removing the manual call is safe in both stacks and silences the deprecation warning today while preventing a future build break.

Ref #22

## Test plan
- [x] Compiles cleanly on `esp32:esp32:esp32s3` (arduino-esp32 3.3.7) for `examples/T-Display-S3-BLE-Receiver` with `--warnings all`, no `BLE2902` / deprecation messages remain.
- [ ] Runtime verification on hardware (BLE central subscribes and receives MIDI notifications).