### PR TITLE
fix: Allow send to devices with WRITE_NO_RESPONSE property

### DIFF
--- a/src/BLEClientConnection.cpp
+++ b/src/BLEClientConnection.cpp
@@ -180,7 +180,7 @@ bool BLEClientConnection::sendMidiMessage(const uint8_t* data, size_t length) {
     if (xSemaphoreTake(sendMutex, pdMS_TO_TICKS(100)) != pdTRUE) return false;
 
     bool sent = false;
-    if (_connected && pRemoteChar->canWrite()) {
+    if (_connected && (pRemoteChar->canWrite() || pRemoteChar->canWriteNoResponse())) {
         pRemoteChar->writeValue(packet, 2 + midiLen, false);
         sent = true;
     }


### PR DESCRIPTION
Send a message to a client if it has either WRITE or WRITE_NO_RESPONSE properties in the MIDI characteristic instead of accepting only WRITE.

I ran into this with the Yamaha Seqtrak which advertises WRITE=0 and WRITE_NO_RESPONSE=1.