### PR TITLE
v6.0.0: handler optional + BLE/USB-MIDI 2.0 fixes

### DIFF
--- a/docs/migration-v6.md
+++ b/docs/migration-v6.md
@@ -1,9 +1,121 @@
 # Migration Guide: v5.x → v6.0
 
-ESP32_Host_MIDI v5.2 introduces new MIDI spec-compliant fields alongside the existing ones.
-In v6.0, the deprecated fields will be removed. This guide helps you migrate.
+v6.0 contains two breaking changes that require code updates in user
+sketches. Both are independent of each other; you may need one or both
+depending on what your firmware uses.
 
-## Field Mapping
+1. **Transport architecture**: `MIDIHandler` no longer owns built-in USB
+   Host and BLE transports. User code instantiates each transport it
+   uses and registers it with `addTransport()`.
+2. **`MIDIEventData` field cleanup**: the deprecated string / 1-indexed
+   fields added before v5.2 are removed; only the spec-compliant
+   replacements (`statusCode`, `channel0`, etc.) remain.
+
+The two are documented in turn below.
+
+---
+
+## Part 1: Transport architecture (new in v6.0)
+
+### What changed
+
+In v5.x `MIDIHandler` owned `USBConnection` and `BLEConnection` as
+private members and auto-registered them in `begin()`. The umbrella
+header `ESP32_Host_MIDI.h` auto-included both transport headers based
+on chip capability flags. Result: every consumer of the library paid
+the compile cost of USB Host and BLE even when neither was used, and
+the handler API was tied to those two transports specifically.
+
+In v6.0:
+
+- `MIDIHandler` has no built-in transport members.
+- `ESP32_Host_MIDI.h` no longer auto-includes `USBConnection.h` or
+  `BLEConnection.h`. Each transport lives behind its own header and the
+  application includes only what it uses.
+- `MIDIHandler::isBleConnected()` is removed. Query the
+  `BLEConnection` instance directly via its own `isConnected()`.
+- `MIDIHandlerConfig::bleName` is no longer used by `MIDIHandler` (it
+  used to feed the auto-registered BLE transport's `begin()`). Pass the
+  device name explicitly to `BLEConnection::begin()`.
+
+### Migration pattern
+
+For every sketch that relied on `midiHandler.begin()` auto-starting
+USB Host or BLE, add explicit transport instantiation:
+
+```cpp
+// v5.x: relied on auto-start
+#include <ESP32_Host_MIDI.h>
+
+void setup() {
+    MIDIHandlerConfig cfg;
+    cfg.bleName = "My Device";
+    midiHandler.begin(cfg);   // auto-instantiated USB Host + BLE
+}
+```
+
+```cpp
+// v6.0: explicit
+#include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>     // include each transport you actually use
+#include <BLEConnection.h>
+
+USBConnection usbHost;          // declare globally (TinyUSB needs it
+BLEConnection bleHost;          // before USB.begin())
+
+void setup() {
+    MIDIHandlerConfig cfg;
+    midiHandler.addTransport(&usbHost);
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();
+    bleHost.begin("My Device");
+    midiHandler.begin(cfg);
+}
+```
+
+### Available transport headers
+
+```
+#include <USBConnection.h>           // USB Host MIDI 1.0
+#include <USBMIDI2Connection.h>      // USB Host MIDI 2.0 (UMP native)
+#include <USBDeviceConnection.h>     // USB Device MIDI 1.0
+#include <BLEConnection.h>           // BLE peripheral
+#include <UARTConnection.h>          // DIN-5 / TRS UART
+#include <ESPNowConnection.h>        // ESP-NOW peer-to-peer wireless
+#include <RTPMIDIConnection.h>       // RTP-MIDI / Apple MIDI over WiFi
+#include <EthernetMIDIConnection.h>  // Apple MIDI over W5500 / P4 EMAC
+#include <OSCConnection.h>           // OSC bidirectional bridge
+#include <MIDI2UDPConnection.h>      // raw UMP over UDP
+```
+
+### `isBleConnected` replacement
+
+```cpp
+// v5.x
+if (midiHandler.isBleConnected()) { ... }
+```
+
+```cpp
+// v6.0: query the BLE instance directly
+if (bleHost.isConnected()) { ... }
+```
+
+### Why the change
+
+Coupling forced compilation of USB Host and BLE drivers into firmware
+that did not use them. That made trivial Arduino IDE / PlatformIO
+toolchain quirks (BLE std::string vs Arduino String, the BLE2902 CCCD
+descriptor's deprecation, the USB-MIDI 2.0 alt-switch race) cascade
+into build failures or runtime regressions for users who never
+touched the relevant code paths. The decoupling makes each transport
+pay its own cost only when explicitly used, and the library API stops
+pretending those two transports are special among the nine available.
+
+---
+
+## Part 2: `MIDIEventData` field cleanup
+
+### Field Mapping
 
 | v5.x (deprecated in v5.2) | v5.2+ / v6.0 replacement | Notes |
 |---|---|---|
@@ -90,5 +202,6 @@ These fields remain the same in v6.0:
 
 ## Timeline
 
-- **v5.2**: New fields added. Old fields still work but are deprecated.
-- **v6.0**: Deprecated fields removed. Struct becomes POD/trivially-copyable (~32 bytes vs ~160+ bytes).
+- **v5.2**: New `MIDIEventData` fields added. Old fields still work but are deprecated.
+- **v5.2.x**: Bug fixes; transport architecture unchanged.
+- **v6.0**: Deprecated `MIDIEventData` fields removed (`MIDIEventData` becomes POD / trivially-copyable, ~32 bytes vs ~160+ bytes). `MIDIHandler` decoupled from built-in transports (Part 1 above). Bug fixes on top of v5.2.x: BLE compat with arduino-esp32 v2.x and v3.x; explicit SET_INTERFACE in `USBMIDI2Connection`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,6 +102,27 @@ public:
 
 ## Changelog
 
+### v6.0.0 (breaking change)
+
+Refactor estrutural: separação clara entre transport layer (USB Host, BLE, ESP-NOW, RTP-MIDI, etc.) e handler layer (MIDIHandler), além de bug fixes que vinham se acumulando em pontos de divergência arduino-esp32 v2.x/v3.x.
+
+**Breaking changes**
+
+- `MIDIHandler` não tem mais transports built-in. As classes `USBConnection` e `BLEConnection` deixam de ser members privados; user code instancia cada transport explicitamente e registra via `addTransport()`.
+- `MIDIHandler::isBleConnected()` removido. Consultar a instância de `BLEConnection` direto via `isConnected()`.
+- `ESP32_Host_MIDI.h` (umbrella) deixa de auto-incluir `USBConnection.h` e `BLEConnection.h`. Cada transport tem seu próprio header e o user inclui só os que usa.
+- `MIDIHandlerConfig::bleName` deixa de ser usado pelo `MIDIHandler` (era passado pro transport BLE auto-instanciado). Passar nome diretamente em `BLEConnection::begin(name)`.
+- Campos deprecated do `MIDIEventData` removidos (struct vira POD, ~32 bytes em vez de ~160+ bytes). Usar `statusCode`, `channel0`, `noteNumber`, `velocity7`/`velocity16`, `pitchBend14`/`pitchBend32`. Detalhes em `docs/migration-v6.md`.
+
+**Fixes**
+
+- `BLEConnection`: gates condicionais `ESP_ARDUINO_VERSION_MAJOR` para os 3 pontos de divergência v2.x BluedroidArduino vs v3.x NimBLE-Arduino: `BLEDevice::init` (std::string vs String), `BLECharacteristic::getValue` (idem), e o descriptor `BLE2902` (obrigatório em v2.x onde o wrapper Arduino não expõe a CCCD auto-criada, deprecated em v3.x).
+- `USBMIDI2Connection`: emite SET_INTERFACE explícito via control transfer no EP0 logo depois de `usb_host_interface_claim`. Algumas combinações device-side (libDaisy STM32H7 + TinyUSB MIDI 2.0 PR #3571) ficavam presas no Alt 0 mesmo com claim retornando ESP_OK; o IN bulk vinha com pacotes CIN que `_onReceiveUMP` interpretava como UMP inválido. Validado em hardware com Daisy Seed `feat/midi2`: pré-fix CIN MIDI 1.0 chegava como UMP malformado, pós-fix UMP MT 0x4 nativo (velocity 16-bit, CC/PB/CP/PP 32-bit) chega corretamente.
+
+**Examples migrados pro padrão v6 explícito**
+
+USB Host: `AM-MIDI2-Adapter`, `T-Display-S3-Gingoduino`, `T-Display-S3-Piano-Debug`, `T-Display-S3-SysEx`, `USB-Host-Send`, `USB-Host-Send-Test`. USB Host + BLE: `T-Display-S3-Piano`, `T-Display-S3-Queue`. BLE only: `T-Display-S3-BLE-Receiver`. Examples que já usavam `addTransport` explícito (Ethernet-MIDI, P4-Dual-UART-MIDI, RTP-MIDI-WiFi, T-Display-S3-OSC, T-Display-S3-AMoled-MIDI2-UMP, UART-MIDI-Basic, T-Display-S3-USB-Device) não precisaram mudar.
+
 ### v5.2.0
 - MIDIStatus enum com status bytes MIDI reais (0x80–0xE0)
 - Novos campos spec-compliant: statusCode, channel0 (0–15), noteNumber, velocity7, velocity16, pitchBend14, pitchBend32

--- a/examples/AM-MIDI2-Adapter/AM-MIDI2-Adapter.ino
+++ b/examples/AM-MIDI2-Adapter/AM-MIDI2-Adapter.ino
@@ -25,9 +25,11 @@
 
 // ---- 2. ESP32_Host_MIDI + Adapter ----------------------------------------
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>     // v6.0: transports are no longer auto-included
 #include "../../src/MIDI2Adapter.h"
 
 // ---- Instâncias -----------------------------------------------------------
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 umpProcessor umpp;           // processador AM_MIDI2.0Lib — callbacks aqui
 MIDI2Adapter adapter(umpp);  // ponte entre midiHandler e umpp
 
@@ -135,6 +137,8 @@ void setup() {
     MIDIHandlerConfig cfg;
     cfg.maxEvents    = 20;
     cfg.maxSysExSize = 256;
+    midiHandler.addTransport(&usbHost);  // v6.0: explicit
+    usbHost.begin();                      // v6.0: user owns lifecycle
     midiHandler.begin(cfg);
 
     // ---- Conectar o adapter ----------------------------------------------

--- a/examples/T-Display-S3-BLE-Receiver/T-Display-S3-BLE-Receiver.ino
+++ b/examples/T-Display-S3-BLE-Receiver/T-Display-S3-BLE-Receiver.ino
@@ -17,11 +17,13 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <BLEConnection.h>   // v6.0: transports are no longer auto-included
 #include "PianoDisplay.h"
 #include "SynthEngine.h"
 #include "mapping.h"
 
 // ── Global instances ──────────────────────────────────────────────────────────
+BLEConnection bleHost;       // v6.0: explicit BLE peripheral transport
 SynthEngine synth;
 
 // ── Active notes state ────────────────────────────────────────────────────────
@@ -68,6 +70,8 @@ void setup() {
     cfg.maxEvents       = 64;
     cfg.chordTimeWindow = 0;
     cfg.bleName         = "ESP32 BLE Piano";   // Sender scans for this name
+    midiHandler.addTransport(&bleHost);  // v6.0: explicit
+    bleHost.begin("ESP32 BLE Piano");      // v6.0: user owns lifecycle
     midiHandler.begin(cfg);
 
     synth.begin();
@@ -106,8 +110,10 @@ void loop() {
         }
     }
 
-    // Update BLE status every frame
-    info.bleConnected = midiHandler.isBleConnected();
+    // Update BLE status every frame.
+    // v6.0: query the BLEConnection instance directly (MIDIHandler::
+    // isBleConnected was removed when the built-in BLE member was dropped).
+    info.bleConnected = bleHost.isConnected();
 
     uint32_t now = micros();
     if (now - lastFrameUs >= FRAME_US) {

--- a/examples/T-Display-S3-Gingoduino/T-Display-S3-Gingoduino.ino
+++ b/examples/T-Display-S3-Gingoduino/T-Display-S3-Gingoduino.ino
@@ -16,8 +16,11 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0: transports are no longer auto-included
 #include <GingoAdapter.h>
 #include "ST7789_Handler.h"
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 
 using namespace gingoduino;
 
@@ -71,6 +74,8 @@ void setup() {
     config.chordTimeWindow = 50;
     config.bleName = "ESP32 Gingoduino";
 
+    midiHandler.addTransport(&usbHost);  // v6.0: explicit
+    usbHost.begin();                      // v6.0: user owns lifecycle
     midiHandler.begin(config);
 
     display.print("MIDI + Gingoduino\nReady!\n\nPlay notes...");

--- a/examples/T-Display-S3-Piano-Debug/T-Display-S3-Piano-Debug.ino
+++ b/examples/T-Display-S3-Piano-Debug/T-Display-S3-Piano-Debug.ino
@@ -23,6 +23,9 @@
 #include <Arduino.h>
 #include <LovyanGFX.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0: transports are no longer auto-included
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 #include "mapping.h"
 
 // ── LGFX — T-Display S3 (ST7789, 8-bit parallel) ────────────────────────────
@@ -293,6 +296,8 @@ void setup() {
     cfg.maxEvents       = 64;
     cfg.chordTimeWindow = 0;
     cfg.bleName         = "ESP32-Debug";
+    midiHandler.addTransport(&usbHost);  // v6.0: explicit
+    usbHost.begin();                      // v6.0: user owns lifecycle
     midiHandler.begin(cfg);
 
     midiHandler.setRawMidiCallback(onRawMidi);

--- a/examples/T-Display-S3-Piano/T-Display-S3-Piano.ino
+++ b/examples/T-Display-S3-Piano/T-Display-S3-Piano.ino
@@ -14,6 +14,8 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0: transports are no longer auto-included
+#include <BLEConnection.h>
 #include <GingoAdapter.h>
 #include "PianoDisplay.h"
 #include "SynthEngine.h"
@@ -22,6 +24,8 @@
 using namespace gingoduino;
 
 // ── Global instances ──────────────────────────────────────────────────────────
+USBConnection usbHost;       // v6.0: explicit USB Host (Arturia, etc.)
+BLEConnection bleHost;       // v6.0: explicit BLE peripheral (iPad, iPhone)
 SynthEngine synth;
 
 // ── Active notes state ────────────────────────────────────────────────────────
@@ -120,6 +124,10 @@ void setup() {
     cfg.maxEvents       = 64;
     cfg.chordTimeWindow = 0;
     cfg.bleName         = "ESP32 Piano";
+    midiHandler.addTransport(&usbHost);  // v6.0: explicit
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();
+    bleHost.begin("ESP32 Piano");
     midiHandler.begin(cfg);
 
     synth.begin();

--- a/examples/T-Display-S3-Queue/T-Display-S3-Queue.ino
+++ b/examples/T-Display-S3-Queue/T-Display-S3-Queue.ino
@@ -4,8 +4,13 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0: transports are no longer auto-included
+#include <BLEConnection.h>
 #include "ST7789_Handler.h"
 #include "mapping.h"
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
+BLEConnection bleHost;       // v6.0: explicit BLE peripheral
 
 // Delay for displaying initialization messages (ms)
 static const unsigned long INIT_DISPLAY_DELAY = 500;
@@ -21,6 +26,10 @@ void setup() {
   display.print("Display OK...");
   delay(INIT_DISPLAY_DELAY);
 
+  midiHandler.addTransport(&usbHost);  // v6.0: explicit
+  midiHandler.addTransport(&bleHost);
+  usbHost.begin();
+  bleHost.begin("ESP32 Queue");
   midiHandler.begin();
   display.print("MIDI Handler initialized...");
 

--- a/examples/T-Display-S3-SysEx/T-Display-S3-SysEx.ino
+++ b/examples/T-Display-S3-SysEx/T-Display-S3-SysEx.ino
@@ -8,8 +8,11 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0: transports are no longer auto-included
 #include "ST7789_Handler.h"
 #include "mapping.h"
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 
 static const unsigned long INIT_DISPLAY_DELAY = 500;
 static const int MAX_DISPLAY_LINES = 11;
@@ -69,6 +72,8 @@ void setup() {
   MIDIHandlerConfig config;
   config.maxSysExSize = 256;
   config.maxSysExEvents = 8;
+  midiHandler.addTransport(&usbHost);  // v6.0: explicit
+  usbHost.begin();                      // v6.0: user owns lifecycle
   midiHandler.begin(config);
 
   display.print("SysEx Monitor ready.\nConnect USB MIDI device.\nBTN1=Identity Request\nBTN2=Clear");

--- a/examples/T-Display-S3-USB-Device/T-Display-S3-USB-Device.ino
+++ b/examples/T-Display-S3-USB-Device/T-Display-S3-USB-Device.ino
@@ -23,13 +23,18 @@
 #include <Arduino.h>
 #define ESP32_HOST_MIDI_NO_USB_HOST  // Use USB Device mode, not Host
 #include <ESP32_Host_MIDI.h>
+#include <BLEConnection.h>           // v6.0: transports are no longer auto-included
 #include "../../src/USBDeviceConnection.h"
 #include "mapping.h"
 #include "ST7789_Handler.h"
 
-// MUST be global — TinyUSB registers the USB descriptor on construction,
+// MUST be global. TinyUSB registers the USB descriptor on construction,
 // before USB.begin() is called. The name comes from mapping.h.
 USBDeviceConnection usbMIDI(USB_MIDI_DEVICE_NAME);
+
+// v6.0: BLE transport is also explicit. v5 auto-started BLE inside
+// midiHandler.begin(); v6 leaves the user in charge.
+BLEConnection bleHost;
 
 static int    lastEventIndex = -1;
 static int    inCount        = 0;
@@ -81,11 +86,16 @@ void setup() {
 
     display.init();
 
-    // Register USB Device transport (BLE is registered automatically by begin()).
+    // v6.0: register both transports explicitly. USB Device first,
+    // then BLE peripheral. Each transport owns its own begin().
     midiHandler.addTransport(&usbMIDI);
+    midiHandler.addTransport(&bleHost);
 
     // Start USB stack (enumerates on the host as a MIDI device).
     usbMIDI.begin();
+
+    // Start BLE peripheral, advertising the same name as USB Device.
+    bleHost.begin(USB_MIDI_DEVICE_NAME);
 
     MIDIHandlerConfig cfg;
     cfg.maxEvents = 40;
@@ -102,7 +112,10 @@ void loop() {
     if (millis() - lastStatusCheck >= 2000) {
         lastStatusCheck = millis();
 
-        bool ble = midiHandler.isBleConnected();
+        // v6.0: query BLE state directly on the BLEConnection instance.
+        // MIDIHandler::isBleConnected was removed when the built-in BLE
+        // member was dropped.
+        bool ble = bleHost.isConnected();
         if (ble != lastBLE) {
             lastBLE = ble;
             display.setBLE(ble);

--- a/examples/USB-Host-Send-Test/USB-Host-Send-Test.ino
+++ b/examples/USB-Host-Send-Test/USB-Host-Send-Test.ino
@@ -19,6 +19,9 @@
 
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>  // v6.0: transports are no longer auto-included
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 
 static bool testDone = false;
 static int passed = 0;
@@ -124,6 +127,8 @@ void setup() {
     delay(1000);
     Serial.println("USB-Host-Send-Test: waiting for USB MIDI device...");
 
+    midiHandler.addTransport(&usbHost);  // v6.0: explicit
+    usbHost.begin();                      // v6.0: user owns lifecycle
     midiHandler.begin();
 }
 

--- a/examples/USB-Host-Send/USB-Host-Send.ino
+++ b/examples/USB-Host-Send/USB-Host-Send.ino
@@ -1,5 +1,8 @@
 #include <Arduino.h>
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>  // v6.0: transports are no longer auto-included
+
+USBConnection usbHost;       // v6.0: explicit USB Host transport
 
 #define PEDAL_PIN 4
 #define OUT_PIN5 5 // piano detectado
@@ -42,6 +45,8 @@ void setup() {
   digitalWrite(OUT_PIN6, LOW);
   digitalWrite(OUT_PIN7, LOW);
 
+  midiHandler.addTransport(&usbHost);  // v6.0: explicit
+  usbHost.begin();                      // v6.0: user owns lifecycle
   midiHandler.begin();
   hostIniciado = true;
   momentoInicioHost = millis();

--- a/extras/tests/test_handler.cpp
+++ b/extras/tests/test_handler.cpp
@@ -715,6 +715,139 @@ void test_edge_cases() {
 }
 
 // ---------------------------------------------------------------------------
+// v6 regression tests: handler optional, transports explicit
+// ---------------------------------------------------------------------------
+//
+// Three guards against re-introducing the v5 auto-start coupling:
+//   1. MIDIHandler with zero registered transports stays alive and inert.
+//   2. addTransport multi-transport fan-out: task() pumps every registered
+//      transport; injected MIDI from one transport reaches the queue;
+//      sendNoteOn fires the first transport that accepts.
+//   3. MIDIHandlerConfig::bleName no longer triggers a hidden BLE auto-
+//      start inside begin().
+//
+// MockMidiTransport is a minimal MIDITransport implementation that counts
+// task() calls, exposes inject() to fire dispatchMidiData from outside,
+// and reports sendMidiMessage success.
+
+class MockMidiTransport : public MIDITransport {
+public:
+    int  taskCount = 0;
+    int  sentCount = 0;
+
+    void task() override { taskCount++; }
+    bool isConnected() const override { return true; }
+    bool sendMidiMessage(const uint8_t* data, size_t length) override {
+        (void)data; (void)length;
+        sentCount++;
+        return true;
+    }
+    // Public wrapper around dispatchMidiData (which is protected on
+    // MIDITransport). Lets the test hand-feed bytes into the handler
+    // through this transport's registered callback.
+    void inject(const uint8_t* data, size_t len) {
+        dispatchMidiData(data, len);
+    }
+};
+
+void test_v6_handler_no_transports() {
+    printf("\n[v6: Handler standalone (no transports added)]\n");
+
+    MIDIHandler h;
+
+    TEST("begin() with no addTransport does not crash");
+    h.begin();
+    PASS();
+
+    TEST("task() with no transports is a no-op");
+    g_fakeMillis = 50000;
+    for (int i = 0; i < 10; i++) h.task();
+    PASS();
+
+    TEST("getQueue() is empty when no transport is feeding");
+    ASSERT(h.getQueue().empty());
+    PASS();
+
+    TEST("sendNoteOn() returns false when no transport accepts");
+    bool sent = h.sendNoteOn(1, 60, 100);
+    ASSERT(!sent);
+    PASS();
+
+    TEST("getActiveNotesCount() == 0 with empty handler");
+    ASSERT_EQ((int)h.getActiveNotesCount(), 0);
+    PASS();
+}
+
+void test_v6_multi_transport_fan_out() {
+    printf("\n[v6: addTransport multi-transport fan-out]\n");
+
+    MIDIHandler h;
+    MockMidiTransport t1, t2, t3;
+    h.addTransport(&t1);
+    h.addTransport(&t2);
+    h.addTransport(&t3);
+    h.begin();
+    g_fakeMillis = 51000;
+
+    TEST("task() pumps every registered transport once");
+    h.task();
+    ASSERT_EQ(t1.taskCount, 1);
+    ASSERT_EQ(t2.taskCount, 1);
+    ASSERT_EQ(t3.taskCount, 1);
+    PASS();
+
+    TEST("inject from transport #1 reaches the handler queue");
+    uint8_t noteon[3] = { 0x90, 60, 100 };
+    t1.inject(noteon, 3);
+    ASSERT_EQ((int)h.getQueue().size(), 1);
+    ASSERT(h.getQueue().back().statusCode == MIDI_NOTE_ON);
+    ASSERT_EQ(h.getQueue().back().noteNumber, 60);
+    PASS();
+
+    TEST("inject from transport #3 reaches the same queue");
+    uint8_t noteoff[3] = { 0x80, 60, 0 };
+    t3.inject(noteoff, 3);
+    ASSERT_EQ((int)h.getQueue().size(), 2);
+    ASSERT(h.getQueue().back().statusCode == MIDI_NOTE_OFF);
+    PASS();
+
+    TEST("sendNoteOn() stops at the first accepting transport");
+    bool sent = h.sendNoteOn(1, 64, 100);
+    ASSERT(sent);
+    ASSERT_EQ(t1.sentCount, 1);
+    ASSERT_EQ(t2.sentCount, 0);  // not called, t1 already accepted
+    ASSERT_EQ(t3.sentCount, 0);
+    PASS();
+}
+
+void test_v6_blename_not_auto_consumed() {
+    printf("\n[v6: MIDIHandlerConfig::bleName not auto-consumed]\n");
+
+    MIDIHandler h;
+    MIDIHandlerConfig cfg;
+    cfg.bleName = "Should be ignored by handler in v6";
+
+    TEST("begin(cfg) with bleName set does not crash");
+    h.begin(cfg);
+    PASS();
+
+    TEST("no transport auto-registered (sendNoteOn returns false)");
+    // In v5 this call would have fanned out to the auto-started BLE
+    // transport. In v6 nothing is registered; the call has no path.
+    bool sent = h.sendNoteOn(1, 60, 100);
+    ASSERT(!sent);
+    PASS();
+
+    TEST("explicit mock transport still works after bleName cfg");
+    MockMidiTransport t;
+    h.addTransport(&t);
+    bool sent2 = h.sendNoteOn(1, 60, 100);
+    ASSERT(sent2);
+    ASSERT_EQ(t.sentCount, 1);
+    PASS();
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
@@ -739,6 +872,9 @@ int main() {
     test_event_metadata();
     test_raw_midi_format();
     test_edge_cases();
+    test_v6_handler_no_transports();
+    test_v6_multi_transport_fan_out();
+    test_v6_blename_not_auto_consumed();
 
     printf("\n================================================\n");
     printf("Results: %d passed, %d failed\n", g_pass, g_fail);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Host_MIDI
-version=5.2.0
+version=6.0.0
 author=sauloverissimo
 maintainer=Saulo Verissimo <sauloverissimo@gmail.com>
 sentence=MIDI hub for ESP32 — USB Host, BLE, Apple MIDI/WiFi, OSC, Ethernet, UART/DIN-5, ESP-NOW, USB Device.

--- a/src/BLEConnection.cpp
+++ b/src/BLEConnection.cpp
@@ -1,5 +1,16 @@
 #include "BLEConnection.h"
 
+// BLE stack drift between arduino-esp32 v2.x (BluedroidArduino) and
+// arduino-esp32 v3.x (NimBLE-Arduino) needs three #if branches inside
+// begin() below. v2.x also requires the explicit BLE2902 CCCD descriptor
+// because the BluedroidArduino wrapper does not expose the auto-created
+// CCCD via the Arduino API; clients (iOS, macOS, DAWs) cannot subscribe
+// to notifications without it. v3.x flags BLE2902 as deprecated and
+// auto-creates the CCCD when NOTIFY is set, so the include is gated.
+#if !defined(ESP_ARDUINO_VERSION_MAJOR) || ESP_ARDUINO_VERSION_MAJOR < 3
+  #include <BLE2902.h>
+#endif
+
 BLEConnection::BLEConnection()
     : pServer(nullptr), pCharacteristic(nullptr),
       pBleCallback(nullptr), pServerCallback(nullptr),
@@ -25,7 +36,14 @@ void BLEConnection::begin(const std::string& deviceName) {
 
     sendMutex = xSemaphoreCreateMutex();
 
+    // BLEDevice::init signature differs by stack:
+    //   v2.x BluedroidArduino : init(std::string)
+    //   v3.x NimBLE-Arduino   : init(String)
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
     BLEDevice::init(String(deviceName.c_str()));
+#else
+    BLEDevice::init(deviceName);
+#endif
     pServer = BLEDevice::createServer();
 
     // Server callbacks: handle connect/disconnect and restart advertising automatically.
@@ -55,15 +73,22 @@ void BLEConnection::begin(const std::string& deviceName) {
     BLEService* pService = pServer->createService(BLE_MIDI_SERVICE_UUID);
 
     // BLE MIDI spec requires READ + NOTIFY + WRITE_NR.
-    // The CCCD (0x2902) descriptor is added automatically by the underlying stack
-    // (NimBLE in arduino-esp32 3.x; BlueDroid in 2.x) whenever NOTIFY/INDICATE is set,
-    // so we no longer add it manually (BLE2902 is deprecated and will be removed).
     pCharacteristic = pService->createCharacteristic(
         BLE_MIDI_CHARACTERISTIC_UUID,
         BLECharacteristic::PROPERTY_READ    |
         BLECharacteristic::PROPERTY_NOTIFY  |
         BLECharacteristic::PROPERTY_WRITE_NR
     );
+
+    // CCCD (0x2902) descriptor handling, v2.x vs v3.x split:
+    //   v2.x BluedroidArduino : Arduino wrapper does NOT expose the auto-
+    //     created CCCD; clients (iOS, macOS, Bitwig, Logic) cannot subscribe
+    //     to notifications without an explicit BLE2902 descriptor. Keep it.
+    //   v3.x NimBLE-Arduino   : auto-creates the CCCD whenever NOTIFY is set
+    //     and flags addDescriptor(BLE2902) as [[deprecated]]; omit it.
+#if !defined(ESP_ARDUINO_VERSION_MAJOR) || ESP_ARDUINO_VERSION_MAJOR < 3
+    pCharacteristic->addDescriptor(new BLE2902());
+#endif
 
     // Receive callback: strips the 2-byte BLE MIDI header and enqueues raw MIDI bytes.
     // BLE MIDI packet format: [header][timestamp][midi_bytes...]
@@ -73,7 +98,15 @@ void BLEConnection::begin(const std::string& deviceName) {
         BLEConnection* bleCon;
         BLECallback(BLEConnection* con) : bleCon(con) {}
         void onWrite(BLECharacteristic* characteristic) override {
+            // getValue() return type differs by stack:
+            //   v2.x BluedroidArduino : returns std::string
+            //   v3.x NimBLE-Arduino   : returns Arduino String
+            // Both expose .length() and .c_str() with the signatures we use.
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
             String rxValue = characteristic->getValue();
+#else
+            std::string rxValue = characteristic->getValue();
+#endif
             size_t len = rxValue.length();
             // Minimum valid BLE MIDI packet: header + timestamp + 1 MIDI byte = 3 bytes
             if (len >= 3) {

--- a/src/ESP32_Host_MIDI.h
+++ b/src/ESP32_Host_MIDI.h
@@ -38,21 +38,39 @@
   #define ESP32_HOST_MIDI_HAS_ETH_MAC 0
 #endif
 
-// --- Includes ---
+// --- Includes (v6.0) ---
+//
+// This umbrella header now exposes only the always-on pieces:
+//   * MIDITransport          (the transport interface)
+//   * MIDIHandlerConfig      (config struct used by MIDIHandler)
+//   * MIDIHandler            (optional aggregator)
+//
+// In v5.x and earlier, this header auto-included USBConnection and
+// BLEConnection so a single `#include <ESP32_Host_MIDI.h>` would arrange
+// both into a default firmware. That made every consumer of the library
+// pay for compiling those two files, even firmware that used neither.
+// It also coupled the MIDIHandler API to those two transports
+// specifically (the others required addTransport).
+//
+// In v6.0 the auto-includes are gone. Application code is expected to
+// include each transport it actually uses, by name:
+//
+//   #include <USBConnection.h>          // USB Host MIDI 1.0
+//   #include <USBMIDI2Connection.h>     // USB Host MIDI 2.0
+//   #include <USBDeviceConnection.h>    // USB Device MIDI 1.0
+//   #include <BLEConnection.h>
+//   #include <UARTConnection.h>
+//   #include <ESPNowConnection.h>
+//   #include <RTPMIDIConnection.h>
+//   #include <EthernetMIDIConnection.h>
+//   #include <OSCConnection.h>
+//   #include <MIDI2UDPConnection.h>
+//
+// MIDIHandler is still here, but stripped of its built-in transports.
+// Use addTransport() to wire whichever transports you instantiate.
+// See docs/migration-v6.md for v5 -> v6 migration.
 
 #include "MIDITransport.h"
-
-// USB Host is included by default on S2/S3/P4.
-// Define ESP32_HOST_MIDI_NO_USB_HOST before including this header
-// to exclude it (e.g. when using USBDeviceConnection instead).
-#if ESP32_HOST_MIDI_HAS_USB && !defined(ESP32_HOST_MIDI_NO_USB_HOST)
-  #include "USBConnection.h"
-#endif
-
-#if ESP32_HOST_MIDI_HAS_BLE
-  #include "BLEConnection.h"
-#endif
-
 #include "MIDIHandlerConfig.h"
 #include "MIDIHandler.h"
 

--- a/src/MIDIHandler.cpp
+++ b/src/MIDIHandler.cpp
@@ -47,15 +47,10 @@ void MIDIHandler::begin(const MIDIHandlerConfig& cfg) {
   this->config = cfg;
   this->maxEvents = cfg.maxEvents;
 
-#if ESP32_HOST_MIDI_HAS_USB && !defined(ESP32_HOST_MIDI_NO_USB_HOST)
-  registerTransport(&usbTransport);
-  usbTransport.begin();
-#endif
-
-#if ESP32_HOST_MIDI_HAS_BLE
-  registerTransport(&bleTransport);
-  bleTransport.begin(std::string(cfg.bleName));
-#endif
+  // v6.0: MIDIHandler::begin no longer auto-instantiates USB Host or BLE
+  // transports. User code is responsible for constructing each transport,
+  // registering it via addTransport(), and calling its own begin(). See
+  // docs/migration-v6.md.
 
   if (cfg.historyCapacity > 0) {
     enableHistory(cfg.historyCapacity);
@@ -781,9 +776,6 @@ bool MIDIHandler::sendSysEx(const uint8_t* data, size_t length) {
   return true;
 }
 
-#if ESP32_HOST_MIDI_HAS_BLE
-bool MIDIHandler::isBleConnected() const {
-  return bleTransport.isConnected();
-}
-#endif
+// v6.0: MIDIHandler::isBleConnected() removed. Query the BLEConnection
+// instance directly via its isConnected() method.
 

--- a/src/MIDIHandler.h
+++ b/src/MIDIHandler.h
@@ -46,13 +46,10 @@
   #endif
 #endif
 
-#if ESP32_HOST_MIDI_HAS_USB && !defined(ESP32_HOST_MIDI_NO_USB_HOST)
-  #include "USBConnection.h"
-#endif
-
-#if ESP32_HOST_MIDI_HAS_BLE
-  #include "BLEConnection.h"
-#endif
+// v6.0 separation: MIDIHandler is a pure aggregator. It no longer pulls
+// USBConnection.h or BLEConnection.h via this header. User code includes
+// each transport explicitly and registers it with addTransport().
+// See docs/migration-v6.md for the v5 -> v6 migration path.
 
 // MIDI status byte values — matches the upper nibble of MIDI 1.0 status bytes.
 // Use these with MIDIEventData::statusCode for type-safe, zero-cost comparisons.
@@ -160,9 +157,8 @@ public:
   typedef void (*SysExCallback)(const uint8_t* data, size_t length);
   void setSysExCallback(SysExCallback cb) { sysExCb = cb; }
 
-#if ESP32_HOST_MIDI_HAS_BLE
-  bool isBleConnected() const;
-#endif
+  // v6.0: isBleConnected() removed; query the BLEConnection instance
+  // directly via its isConnected() method instead.
 
   // Chord event utility methods:
   int lastChord(const std::deque<MIDIEventData>& queue) const;
@@ -214,13 +210,8 @@ private:
   SysExCallback sysExCb = nullptr;
   void handleSysExMessage(const uint8_t* data, size_t length);
 
-  // Built-in transports (owned by MIDIHandler, registered automatically in begin())
-#if ESP32_HOST_MIDI_HAS_USB && !defined(ESP32_HOST_MIDI_NO_USB_HOST)
-  USBConnection usbTransport;
-#endif
-#if ESP32_HOST_MIDI_HAS_BLE
-  BLEConnection bleTransport;
-#endif
+  // v6.0: no built-in transport members. User instantiates transports and
+  // registers them via addTransport(). See docs/migration-v6.md.
 };
 
 extern MIDIHandler midiHandler;

--- a/src/USBMIDI2Connection.cpp
+++ b/src/USBMIDI2Connection.cpp
@@ -1,5 +1,8 @@
 #include "USBMIDI2Connection.h"
 #include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
 
 // UMP Stream Message constants (MT 0x0F)
 static const uint8_t  UMP_MT_STREAM            = 0x0F;
@@ -164,6 +167,58 @@ bool USBMIDI2Connection::_claimAndSetup(const AltCandidate& cand) {
         lastError = "MIDI2: claim failed (iface=" + String(cand.ifaceNumber)
                   + " alt=" + String(cand.altSetting) + " err=" + String(err) + ")";
         return false;
+    }
+
+    // Force-resend SET_INTERFACE via EP0 control transfer.
+    //
+    // Per ESP-IDF docs, usb_host_interface_claim already issues SET_INTERFACE
+    // when the requested alt differs from the active one. In practice some
+    // device combinations (notably libDaisy STM32H7 + TinyUSB MIDI 2.0 PR
+    // #3571 device class) silently stay on Alt 0 (USB-MIDI 1.0 CIN) while
+    // the host believes it has switched to Alt 1 (USB-MIDI 2.0 UMP). The
+    // result: bulk IN transfers come back populated with CIN packets that
+    // _onReceiveUMP misinterprets as UMP words with reserved MT nibbles.
+    //
+    // Sending the request explicitly closes the gap. SET_INTERFACE on FS USB
+    // is a single 8-byte SETUP with no data stage; under 1 ms in practice.
+    // We wait up to 200 ms for the transfer callback before freeing the
+    // transfer to avoid use-after-free, then wait another 50 ms for the
+    // device-side class driver to fully repoint its TX path before we start
+    // submitting bulk reads.
+    {
+        static SemaphoreHandle_t s_setifSem = nullptr;
+        if (s_setifSem == nullptr) s_setifSem = xSemaphoreCreateBinary();
+
+        usb_transfer_t* setifT = nullptr;
+        if (usb_host_transfer_alloc(8, 0, &setifT) == ESP_OK && setifT != nullptr) {
+            setifT->device_handle    = deviceHandle;
+            setifT->bEndpointAddress = 0x00;
+            setifT->num_bytes        = 8;
+            setifT->timeout_ms       = 200;
+            setifT->context          = (void*)s_setifSem;
+            setifT->callback         = [](usb_transfer_t* t) {
+                SemaphoreHandle_t sem = (SemaphoreHandle_t)t->context;
+                if (sem) xSemaphoreGive(sem);
+            };
+            // SETUP: bmRequestType=0x01 (host->device, standard, interface),
+            // bRequest=0x0B (SET_INTERFACE), wValue=alt, wIndex=iface, wLength=0.
+            setifT->data_buffer[0] = 0x01;
+            setifT->data_buffer[1] = 0x0B;
+            setifT->data_buffer[2] = cand.altSetting;
+            setifT->data_buffer[3] = 0x00;
+            setifT->data_buffer[4] = cand.ifaceNumber;
+            setifT->data_buffer[5] = 0x00;
+            setifT->data_buffer[6] = 0x00;
+            setifT->data_buffer[7] = 0x00;
+
+            if (usb_host_transfer_submit_control(clientHandle, setifT) == ESP_OK) {
+                xSemaphoreTake(s_setifSem, pdMS_TO_TICKS(200));
+            }
+            usb_host_transfer_free(setifT);
+        }
+        // Settle window: allow the device-side class driver to repoint its
+        // bulk TX path to the new alt before we start reading.
+        vTaskDelay(pdMS_TO_TICKS(50));
     }
 
     // Allocate IN transfer (receive)


### PR DESCRIPTION
## Summary

Breaking-change refactor (v6.0.0) that decouples `MIDIHandler` from the
USB Host and BLE transports it used to own as built-in members, plus
two bug fixes that surfaced while trying to ship v5.2.1.

### Architecture

- `MIDIHandler` no longer owns `USBConnection` or `BLEConnection` as
  private members. User code instantiates each transport explicitly
  and registers it via `addTransport()` before calling
  `midiHandler.begin()`.
- `ESP32_Host_MIDI.h` (umbrella header) no longer auto-includes
  `USBConnection.h` or `BLEConnection.h`. Each transport lives behind
  its own header and the application includes only what it uses.
- `MIDIHandler::isBleConnected()` removed; query the `BLEConnection`
  instance directly via its own `isConnected()`.
- `MIDIHandlerConfig::bleName` no longer auto-consumed by `begin()`;
  pass the device name to `BLEConnection::begin()` directly.

### Fixes

- `BLEConnection`: gates conditional on `ESP_ARDUINO_VERSION_MAJOR` for
  three points of API drift between BluedroidArduino (v2.x) and
  NimBLE-Arduino (v3.x): `BLEDevice::init` (std::string vs Arduino
  String), `BLECharacteristic::getValue` (idem), and the BLE2902 CCCD
  descriptor (required in v2.x where the Arduino wrapper does not
  expose the auto-created CCCD; deprecated in v3.x).
- `USBMIDI2Connection`: emits SET_INTERFACE explicitly via control
  transfer on EP0 right after `usb_host_interface_claim`. Some device
  combinations (libDaisy STM32H7 + TinyUSB MIDI 2.0 PR #3571) silently
  stayed on Alt 0 (USB-MIDI 1.0 CIN) while the host believed it had
  switched to Alt 1 (UMP native).

### Validation

- 263 native tests passing (32 + 111 + 120; +12 new v6 regression
  guards in `test_handler`).
- Hardware test: ESP32-S3 with on-board OTG jumper running the v6
  library against a Daisy Seed (libDaisy `feat/midi2`). Daisy delivers
  UMP MT 0x4 packets with 16-bit velocity and 32-bit CC / pitch bend /
  pressure values to a downstream consumer's typed dispatch. Pre-fix
  the same hardware delivered CIN-format MIDI 1.0 packets that the
  host misinterpreted as UMP with reserved MT nibbles.

### Migration

`docs/migration-v6.md` Part 1 walks through the v5 to v6 migration
pattern with side-by-side examples and the full list of transport
headers to include explicitly. Part 2 (existing) covers the
`MIDIEventData` deprecated fields cleanup that was already targeted
for v6.0.

## Test plan

- [x] Native test suite: `g++ -Iextras/tests/stub -Isrc ... extras/tests/test_*.cpp`
  passes 263 / 263.
- [x] Recipe consumer build: `midi2_cpp/examples/esp32-s3-devkitc-host-midi2`
  builds via PlatformIO `espressif32@^6.7.0` (arduino-esp32 v2.0.17),
  zero warnings, 23.3 KB RAM, 334 KB flash.
- [x] Hardware: Daisy Seed plugged into ESP32-S3 OTG host port via OTG
  jumper, UMP MT 0x4 traffic observed in serial log post-fix.
- [ ] CI Arduino compile-sketches against arduino-esp32 v3.x (NimBLE)
  via gh-pages package index — gated on this PR.