### PR TITLE
docs(v6): align all guides + READMEs with explicit-transport API

### DIFF
--- a/README-PT-BR.md
+++ b/README-PT-BR.md
@@ -421,19 +421,30 @@ lib_deps =
 ## Referência da API
 
 ```cpp
-midiHandler.begin();                // inicia transportes built-in
-midiHandler.task();                 // chamar em cada loop()
-midiHandler.addTransport(&t);       // registrar transporte externo
+// Setup (v6.0+: cada transporte é explícito)
+USBConnection usb;                 // inclua os transportes que vai usar:
+BLEConnection ble;                 //   #include <USBConnection.h>, <BLEConnection.h>, ...
+midiHandler.addTransport(&usb);    // registra cada transporte
+midiHandler.addTransport(&ble);
+usb.begin();                       // o user controla o ciclo de vida de cada um
+ble.begin("Meu Device");
+midiHandler.begin();               // opcional: defaults
+midiHandler.begin(cfg);            // ou com config custom
+midiHandler.task();                // chamar em cada loop()
 
-const auto& q = midiHandler.getQueue();
+// Receber
+const auto& q = midiHandler.getQueue();                          // ring buffer
 std::vector<std::string> n = midiHandler.getActiveNotesVector(); // ["C4","E4","G4"]
-std::string chord = midiHandler.getChordName();                  // "Cmaj7"
+size_t count = midiHandler.getActiveNotesCount();                // notas ativas
+// Acordes, intervalos e escalas vêm da lib opcional Gingoduino
+// (veja docs/funcionalidades/gingo-adapter.md), não do MIDIHandler.
 
+// Enviar (fan-out: tenta cada transporte registrado, retorna true no primeiro aceito)
 midiHandler.sendNoteOn(ch, note, vel);
 midiHandler.sendNoteOff(ch, note, vel);
 midiHandler.sendControlChange(ch, ctrl, val);
 midiHandler.sendProgramChange(ch, prog);
-midiHandler.sendPitchBend(ch, val);   // 0–16383, centro = 8192
+midiHandler.sendPitchBend(ch, val);   // -8192..+8191, centro = 0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ for (const auto& ev : midiHandler.getQueue()) {
 ║                                              │                      ║
 ║                                              ▼                      ║
 ║                                     sendMidiMessage()               ║
-║                                  (broadcasts to ALL transports)     ║
+║                                  (fan-out: first transport accepts) ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -670,30 +670,42 @@ USB Host and USB Device require **arduino-esp32 ≥ 3.0** (TinyUSB MIDI).
 ### API Reference
 
 ```cpp
-// Setup
-midiHandler.begin();               // start built-in transports (USB, BLE, ESP-NOW)
-midiHandler.begin(cfg);            // with custom config
-midiHandler.addTransport(&t);      // register external transport
+// Setup (v6.0+: every transport is explicit)
+USBConnection usb;                 // include the transports you actually use
+BLEConnection ble;                 //   #include <USBConnection.h>, <BLEConnection.h>, ...
+midiHandler.addTransport(&usb);    // register each transport
+midiHandler.addTransport(&ble);
+usb.begin();                       // user owns each transport's lifecycle
+ble.begin("My Device");
+midiHandler.begin();               // optional: defaults
+midiHandler.begin(cfg);            // or with custom config
 
 // Receive
-const auto& q = midiHandler.getQueue();                        // event ring buffer
+const auto& q = midiHandler.getQueue();                          // event ring buffer
 std::vector<std::string> n = midiHandler.getActiveNotesVector(); // ["C4","E4","G4"]
-std::string chord = midiHandler.getChordName();                 // "Cmaj7"
+size_t count = midiHandler.getActiveNotesCount();                // active note count
+// Chord / interval / scale names come from the optional Gingoduino library
+// (see docs/funcionalidades/gingo-adapter.md), not from MIDIHandler itself.
 
-// Send (broadcasts to ALL transports simultaneously)
+// Send (fan-out: tries every registered transport, returns true on first acceptance)
 midiHandler.sendNoteOn(ch, note, vel);
 midiHandler.sendNoteOff(ch, note, vel);
 midiHandler.sendControlChange(ch, ctrl, val);
 midiHandler.sendProgramChange(ch, prog);
-midiHandler.sendPitchBend(ch, val);          // 0–16383, center = 8192
+midiHandler.sendPitchBend(ch, val);          // -8192..+8191, center = 0
 ```
 
 **MIDIHandlerConfig:**
 ```cpp
 MIDIHandlerConfig cfg;
-cfg.maxEvents      = 20;    // queue capacity
-cfg.enableHistory  = true;  // keep full history
-cfg.chordDetection = true;  // group simultaneous notes
+cfg.maxEvents         = 20;    // queue capacity (1..100)
+cfg.chordTimeWindow   = 50;    // ms grouping for chord detection (0 = legacy)
+cfg.velocityThreshold = 0;     // ignore NoteOn below this velocity (0..127)
+cfg.historyCapacity   = 0;     // PSRAM history buffer (0 = disabled)
+cfg.maxSysExSize      = 512;   // bytes per SysEx (0 = disable SysEx)
+cfg.maxSysExEvents    = 8;     // SysEx queue depth
+// cfg.bleName: legacy field, ignored by MIDIHandler in v6+; pass the
+// device name to BLEConnection::begin() directly.
 ```
 
 **Custom transport interface:**

--- a/docs/api/referencia.md
+++ b/docs/api/referencia.md
@@ -97,7 +97,9 @@ struct MIDIHandlerConfig {
     // Capacidade da fila de SysEx. Mensagens mais antigas são descartadas.
 
     const char* bleName = "ESP32 MIDI BLE";
-    // Nome anunciado pelo periférico BLE MIDI.
+    // legacy v5: o handler passava esse nome ao BLEConnection auto-instanciado.
+    // Em v6+ o handler não auto-instancia transportes; passe o nome direto pra
+    // BLEConnection::begin(name). Campo mantido por compatibilidade binária.
 };
 ```
 
@@ -111,14 +113,16 @@ Singleton global: `extern MIDIHandler midiHandler;`
 
 ```cpp
 void begin();
-// Inicializa com configuração padrão.
-// Registra automaticamente: USBConnection (se S2/S3/P4), BLEConnection (se BT habilitado)
+// Inicializa com configuração padrão. Em v6+ NÃO registra nenhum transporte:
+// o user instancia cada transport (USBConnection, BLEConnection, etc.) e
+// chama addTransport() antes de begin().
 
 void begin(const MIDIHandlerConfig& config);
-// Inicializa com configuração personalizada.
+// Inicializa com configuração personalizada. Mesmo contrato que begin():
+// transports devem ser registrados via addTransport() antes desta chamada.
 
 void addTransport(MIDITransport* transport);
-// Registra um transporte externo (até 4 transportes externos adicionais).
+// Registra um transporte. Suporta até 4 transports.
 // Deve ser chamado ANTES de begin().
 
 void setQueueLimit(int maxEvents);
@@ -249,14 +253,14 @@ struct MIDISysExEvent {
 
 ### Envio de MIDI
 
-> **Nota:** Na v5.2, a API de envio usa canal 1–16. Na v6.0, será migrada para 0–15 (MIDI spec).
+> **Nota:** A API de envio usa canal 1–16 em v5.x e v6.x. A possível migração para 0–15 fica para uma versão futura.
 
-Todos os métodos de envio transmitem para **todos os transportes** que suportam envio:
+Todos os métodos de envio fazem **fan-out**: tentam cada transporte registrado em ordem e retornam `true` no primeiro que aceitar. Não é broadcast simultâneo.
 
 ```cpp
 bool sendNoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
 // channel: 1–16 | note: 0–127 | velocity: 0–127
-// Retorna true se pelo menos um transporte enviou.
+// Retorna true se algum transporte aceitou.
 
 bool sendNoteOff(uint8_t channel, uint8_t note, uint8_t velocity);
 // velocity tipicamente 0 para NoteOff.
@@ -272,19 +276,20 @@ bool sendPitchBend(uint8_t channel, int value);
 // value: -8192 a +8191 (convertido internamente para 0–16383)
 
 bool sendRaw(const uint8_t* data, size_t length);
-// Envia bytes MIDI crus para todos os transportes.
+// Envia bytes MIDI crus, mesmo padrão fan-out.
 
 bool sendBleRaw(const uint8_t* data, size_t length);
 // Alias de sendRaw() (compatibilidade retroativa).
 ```
 
-### BLE Status
+### BLE Status (v6+: consultar a instância de BLEConnection)
 
 ```cpp
-#if ESP32_HOST_MIDI_HAS_BLE
-bool isBleConnected() const;
-// Retorna true se um dispositivo BLE MIDI estiver conectado.
-#endif
+// v6+: o método MIDIHandler::isBleConnected foi removido junto com o
+// member built-in BLEConnection. Consulte direto na sua instância:
+BLEConnection bleHost;
+// ...
+if (bleHost.isConnected()) { /* BLE central conectado */ }
 ```
 
 ### Debug Callback
@@ -341,11 +346,15 @@ protected:
 
 ## USBConnection
 
-Transporte USB Host. Incluído automaticamente em chips S2/S3/P4.
+Transporte USB Host MIDI 1.0. Em v6+ o user instancia explicitamente.
 
 ```cpp
-// Uso interno — não instancie diretamente.
-// Configuração: Tools > USB Mode → "USB Host"
+#include <USBConnection.h>
+
+USBConnection usbHost;       // global; TinyUSB precisa antes de begin
+midiHandler.addTransport(&usbHost);
+usbHost.begin();             // inicia stack USB Host (FreeRTOS task no core 0)
+// Configuração Arduino IDE: Tools > USB Mode → "USB Host"
 ```
 
 ---
@@ -377,11 +386,17 @@ usb.sendUMPMessage(words, count); // enviar UMP words via OUT endpoint
 
 ## BLEConnection
 
-Transporte BLE MIDI. Incluído automaticamente se `CONFIG_BT_ENABLED`.
+Transporte BLE MIDI peripheral. Em v6+ o user instancia explicitamente.
 
 ```cpp
-// Uso interno — não instancie diretamente.
-// Nome configurado via MIDIHandlerConfig::bleName
+#include <BLEConnection.h>
+
+BLEConnection bleHost;
+midiHandler.addTransport(&bleHost);
+bleHost.begin("Meu ESP32");  // nome anunciado pelo BLE peripheral
+
+// Status:
+if (bleHost.isConnected()) { /* central conectada */ }
 ```
 
 ---
@@ -564,6 +579,7 @@ ESP32_HOST_MIDI_HAS_ETH_MAC // 1 se ESP32-P4 (MAC Ethernet nativo)
 
 - `midiHandler.task()` deve ser chamado em **todo** `loop()`, sem bloqueios longos
 - `addTransport()` deve ser chamado **antes** de `begin()`
-- O máximo de transportes externos é **4** (built-ins não contam)
+- O máximo de transports é **4** (em v6+ não há built-ins; todos contam)
+- Cada transport precisa do seu próprio `begin()`. O `MIDIHandler::begin()` não chama `begin()` em nenhum transport
 - Ring buffers são thread-safe com `portMUX` — seguro para FreeRTOS
 - A fila (`getQueue()`) é válida apenas dentro da iteração — não guarde referências além do loop atual

--- a/docs/avancado/hardware.md
+++ b/docs/avancado/hardware.md
@@ -171,7 +171,8 @@ CS   → GPIO (qualquer disponível)
 
 #if ESP32_HOST_MIDI_HAS_BLE
     // BLE disponível — ESP32, S3, C3, C6, H2
-    bool connected = midiHandler.isBleConnected();
+    // v6.0+: consulte a instância de BLEConnection diretamente
+    bool connected = bleHost.isConnected();
 #endif
 
 #if ESP32_HOST_MIDI_HAS_PSRAM

--- a/docs/exemplos/sysex-monitor.md
+++ b/docs/exemplos/sysex-monitor.md
@@ -54,10 +54,17 @@ O exemplo completo está em [`examples/T-Display-S3-SysEx/`](https://github.com/
 O ponto central é a configuração do SysEx:
 
 ```cpp
-MIDIHandlerConfig config;
-config.maxSysExSize = 256;    // máximo de bytes por mensagem
-config.maxSysExEvents = 8;    // quantas mensagens na fila
-midiHandler.begin(config);
+#include <USBConnection.h>      // v6.0+: cada transport explícito
+USBConnection usbHost;
+
+void setup() {
+    MIDIHandlerConfig config;
+    config.maxSysExSize = 256;    // máximo de bytes por mensagem
+    config.maxSysExEvents = 8;    // quantas mensagens na fila
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
+    midiHandler.begin(config);
+}
 ```
 
 E a leitura da fila no loop:

--- a/docs/exemplos/t-display-s3.md
+++ b/docs/exemplos/t-display-s3.md
@@ -69,9 +69,11 @@ examples/T-Display-S3-Piano/
 #include "src/GingoAdapter.h"   // Detecção de acordes
 #include "ST7789_Handler.h"
 #include "mapping.h"
+#include <USBConnection.h>      // v6.0+: cada transport explícito
 // Tools > USB Mode → "USB Host"
 
 ST7789_Handler display;
+USBConnection  usbHost;
 
 void setup() {
     Serial.begin(115200);
@@ -81,6 +83,8 @@ void setup() {
     MIDIHandlerConfig cfg;
     cfg.maxEvents = 20;
     cfg.chordTimeWindow = 50;
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin(cfg);
 }
 

--- a/docs/funcionalidades/deteccao-acordes.md
+++ b/docs/funcionalidades/deteccao-acordes.md
@@ -25,10 +25,18 @@ chordIndex:            2           ← novo índice
 Controla a janela de tempo (ms) para agrupar notas:
 
 ```cpp
-MIDIHandlerConfig cfg;
-cfg.chordTimeWindow = 0;   // 0 ms (padrão): novo acorde só quando TODAS as notas são soltas
-cfg.chordTimeWindow = 50;  // 50 ms: janela de tempo (ideal para teclados físicos)
-midiHandler.begin(cfg);
+#include <USBConnection.h>
+USBConnection usbHost;
+
+void setup() {
+    midiHandler.addTransport(&usbHost);  // v6.0+: registre os transports
+    usbHost.begin();
+
+    MIDIHandlerConfig cfg;
+    cfg.chordTimeWindow = 0;   // 0 ms (padrão): novo acorde só quando TODAS as notas são soltas
+    cfg.chordTimeWindow = 50;  // 50 ms: janela de tempo (ideal para teclados físicos)
+    midiHandler.begin(cfg);
+}
 ```
 
 ```mermaid
@@ -102,13 +110,18 @@ std::vector<std::string> multi = midiHandler.getAnswer({"noteName", "velocity"})
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>     // v6.0+: cada transport explícito
 // Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;
 
 void setup() {
     Serial.begin(115200);
 
     MIDIHandlerConfig cfg;
     cfg.chordTimeWindow = 50;  // agrupa notas dentro de 50ms
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin(cfg);
 }
 

--- a/docs/funcionalidades/gingo-adapter.md
+++ b/docs/funcionalidades/gingo-adapter.md
@@ -53,11 +53,16 @@ flowchart LR
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>     // v6.0+: cada transport explícito
 #include "src/GingoAdapter.h"  // requer Gingoduino ≥ v0.2.2
 // Tools > USB Mode → "USB Host"
 
+USBConnection usbHost;
+
 void setup() {
     Serial.begin(115200);
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin();
 }
 
@@ -155,9 +160,14 @@ if (GingoAdapter::identifyProgression("C", SCALE_MAJOR, branches, 3, &resultado)
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>      // v6.0+: cada transport explícito
 #include "src/GingoAdapter.h"
 
+USBConnection usbHost;
+
 void setup() {
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin();
     // inicializar display aqui
 }

--- a/docs/funcionalidades/historico-psram.md
+++ b/docs/funcionalidades/historico-psram.md
@@ -18,14 +18,24 @@ O `MIDIHandler` pode manter um buffer circular de eventos que persiste além do 
 ### Via MIDIHandlerConfig
 
 ```cpp
-MIDIHandlerConfig cfg;
-cfg.historyCapacity = 500;  // guardar os últimos 500 eventos
-midiHandler.begin(cfg);
+#include <USBConnection.h>      // v6.0+: registre os transports que vai usar
+USBConnection usbHost;
+
+void setup() {
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
+
+    MIDIHandlerConfig cfg;
+    cfg.historyCapacity = 500;  // guardar os últimos 500 eventos
+    midiHandler.begin(cfg);
+}
 ```
 
 ### Via enableHistory() — após begin()
 
 ```cpp
+midiHandler.addTransport(&usbHost);
+usbHost.begin();
 midiHandler.begin();
 midiHandler.enableHistory(500);  // pode ser chamado a qualquer momento
 ```
@@ -138,6 +148,8 @@ MIDIEventData* historyBuffer = nullptr;
 int historySize = 0;
 
 void setup() {
+    midiHandler.addTransport(&usbHost);    // v6.0+: registre os transports
+    usbHost.begin();
     midiHandler.begin();
 
 #if ESP32_HOST_MIDI_HAS_PSRAM
@@ -165,7 +177,9 @@ Coleta uma sessão de improvisação e mostra estatísticas ao final:
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>           // v6.0+: cada transport explícito
 
+USBConnection usbHost;
 std::vector<MIDIEventData> sessao;
 bool gravando = true;
 
@@ -175,6 +189,8 @@ void setup() {
     MIDIHandlerConfig cfg;
     cfg.maxEvents = 20;
     cfg.historyCapacity = 500;
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin(cfg);
 
     Serial.println("Gravando sessão... (pressione botão para parar)");
@@ -185,7 +201,7 @@ void loop() {
 
     if (gravando) {
         for (const auto& ev : midiHandler.getQueue()) {
-            if (ev.status == "NoteOn") {
+            if (ev.statusCode == MIDI_NOTE_ON && ev.velocity7 > 0) {
                 sessao.push_back(ev);
             }
         }
@@ -204,7 +220,7 @@ void analisarSessao() {
 
     // Nota mais tocada
     int contador[128] = {0};
-    for (const auto& ev : sessao) contador[ev.note]++;
+    for (const auto& ev : sessao) contador[ev.noteNumber]++;
 
     int notaMaisTocada = 0;
     for (int i = 1; i < 128; i++) {
@@ -216,7 +232,7 @@ void analisarSessao() {
 
     // Velocidade média
     int somaVel = 0;
-    for (const auto& ev : sessao) somaVel += ev.velocity;
+    for (const auto& ev : sessao) somaVel += ev.velocity7;
     Serial.printf("Velocidade média: %d\n",
         sessao.empty() ? 0 : somaVel / (int)sessao.size());
 }

--- a/docs/funcionalidades/notas-ativas.md
+++ b/docs/funcionalidades/notas-ativas.md
@@ -63,10 +63,15 @@ for (int i = 0; i < 128; i++) {
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>      // v6.0+: cada transport explícito
 // Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;
 
 void setup() {
     Serial.begin(115200);
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
     midiHandler.begin();
 }
 

--- a/docs/funcionalidades/sysex.md
+++ b/docs/funcionalidades/sysex.md
@@ -54,10 +54,17 @@ SysEx usa sua própria `std::deque<MIDISysExEvent>`, completamente separada da f
 ## Configuração
 
 ```cpp
-MIDIHandlerConfig config;
-config.maxSysExSize   = 512;  // máximo de bytes por mensagem (inclui F0 e F7)
-config.maxSysExEvents = 8;    // quantas mensagens manter na fila
-midiHandler.begin(config);
+#include <USBConnection.h>      // v6.0+: registre os transportes que vai usar
+USBConnection usbHost;
+
+void setup() {
+    MIDIHandlerConfig config;
+    config.maxSysExSize   = 512;  // máximo de bytes por mensagem (inclui F0 e F7)
+    config.maxSysExEvents = 8;    // quantas mensagens manter na fila
+    midiHandler.addTransport(&usbHost);
+    usbHost.begin();
+    midiHandler.begin(config);
+}
 ```
 
 | Parâmetro | Default | Descrição |
@@ -105,7 +112,8 @@ midiHandler.setSysExCallback([](const uint8_t* data, size_t len) {
 ### Envio
 
 ```cpp
-// Enviar SysEx — transmite para todos os transportes
+// Enviar SysEx, broadcast pra todos os transports registrados
+// (sendSysEx itera todos e envia em cada um)
 const uint8_t identityReq[] = { 0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7 };
 bool ok = midiHandler.sendSysEx(identityReq, sizeof(identityReq));
 // Retorna false se a mensagem não começar com F0 ou não terminar com F7

--- a/docs/guia/configuracao.md
+++ b/docs/guia/configuracao.md
@@ -12,17 +12,29 @@ struct MIDIHandlerConfig {
     unsigned long chordTimeWindow = 0;  // Janela para detecção de acordes (ms)
     int velocityThreshold = 0;   // Filtro mínimo de velocidade (0 = desabilitado)
     int historyCapacity  = 0;    // Buffer histórico PSRAM (0 = desabilitado)
-    const char* bleName  = "ESP32 MIDI BLE";  // Nome do dispositivo BLE
+    int maxSysExSize     = 512;  // Tamanho máximo de uma SysEx
+    int maxSysExEvents   = 8;    // Profundidade da fila de SysEx
+    const char* bleName  = "ESP32 MIDI BLE";  // legacy v5 (ver nota)
 };
 ```
+
+!!! note "v6.0+: bleName não é mais consumido pelo MIDIHandler"
+    O campo `bleName` continua na struct para compatibilidade de código antigo, mas em v6+ o `MIDIHandler::begin(cfg)` não inicializa nenhum transporte BLE automaticamente. Passe o nome direto pra `BLEConnection::begin(name)` quando registrar o transporte.
 
 ### Uso básico
 
 ```cpp
-MIDIHandlerConfig cfg;
-cfg.maxEvents = 30;
-cfg.bleName = "Meu Sintetizador";
-midiHandler.begin(cfg);
+#include <BLEConnection.h>
+
+BLEConnection bleHost;     // v6.0+: cada transporte é explícito
+
+void setup() {
+    MIDIHandlerConfig cfg;
+    cfg.maxEvents = 30;
+    midiHandler.addTransport(&bleHost);
+    bleHost.begin("Meu Sintetizador");   // nome BLE vai aqui agora
+    midiHandler.begin(cfg);
+}
 ```
 
 ---
@@ -133,15 +145,19 @@ Veja mais em [Histórico PSRAM →](../funcionalidades/historico-psram.md)
 
 ---
 
-## bleName — Nome do Dispositivo BLE
+## bleName — Nome do Dispositivo BLE (legacy)
 
-Define o nome que aparece nos apps iOS/macOS ao escanear BLE MIDI.
+Em v5, `cfg.bleName` era passado pelo `MIDIHandler::begin()` para o transporte BLE auto-instanciado. Em v6+ o `MIDIHandler` não auto-instancia transportes; o nome BLE vai direto pra `BLEConnection::begin(name)`:
 
 ```cpp
-cfg.bleName = "ESP32 MIDI BLE";      // padrão
-cfg.bleName = "Piano ESP32";          // qualquer string
-cfg.bleName = "Studio Hub";           // aparece em GarageBand, AUM, etc.
+// v6+: passe o nome ao BLEConnection diretamente
+BLEConnection bleHost;
+bleHost.begin("Piano ESP32");        // aparece em GarageBand, AUM, etc.
+midiHandler.addTransport(&bleHost);
+midiHandler.begin();
 ```
+
+O campo `cfg.bleName` continua na struct por compatibilidade binária, mas é ignorado pelo handler em v6+.
 
 ---
 
@@ -159,7 +175,9 @@ A biblioteca detecta automaticamente os recursos disponíveis com base no chip a
 
 // BLE disponível (ESP32, S3, C3, C6 — CONFIG_BT_ENABLED)
 #if ESP32_HOST_MIDI_HAS_BLE
-    bool connected = midiHandler.isBleConnected();
+    // v6.0+: consulte a instância de BLEConnection diretamente.
+    // MIDIHandler::isBleConnected() foi removido junto com o member built-in.
+    bool connected = bleHost.isConnected();
 #endif
 
 // PSRAM disponível (CONFIG_SPIRAM ou CONFIG_SPIRAM_SUPPORT)
@@ -189,6 +207,8 @@ void onRawMidi(const uint8_t* raw, size_t rawLen, const uint8_t* midi3) {
 }
 
 void setup() {
+    midiHandler.addTransport(&usbHost);   // v6.0+: registre seus transportes
+    usbHost.begin();
     midiHandler.setRawMidiCallback(onRawMidi);
     midiHandler.begin();
 }
@@ -212,17 +232,25 @@ midiHandler.clearActiveNotesNow();
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>      // v6.0+: cada transporte explícito
+#include <BLEConnection.h>
+
+USBConnection usbHost;
+BLEConnection bleHost;
 
 void setup() {
     Serial.begin(115200);
 
     MIDIHandlerConfig cfg;
-    cfg.maxEvents         = 30;          // fila maior
-    cfg.chordTimeWindow   = 50;          // agrupar notas de acordes
-    cfg.velocityThreshold = 5;           // ignorar ghost notes
-    cfg.historyCapacity   = 500;         // guardar histórico em PSRAM
-    cfg.bleName           = "Meu ESP32"; // nome no BLE
+    cfg.maxEvents         = 30;     // fila maior
+    cfg.chordTimeWindow   = 50;     // agrupar notas de acordes
+    cfg.velocityThreshold = 5;      // ignorar ghost notes
+    cfg.historyCapacity   = 500;    // guardar histórico em PSRAM
 
+    midiHandler.addTransport(&usbHost);
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();
+    bleHost.begin("Meu ESP32");     // nome BLE direto no transport
     midiHandler.begin(cfg);
 }
 ```

--- a/docs/guia/primeiros-passos.md
+++ b/docs/guia/primeiros-passos.md
@@ -17,17 +17,26 @@ Este sketch imprime todos os eventos MIDI recebidos via USB Host ou BLE no Seria
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0+: cada transporte é explícito
+#include <BLEConnection.h>
 // Arduino IDE: Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;   // (1) instâncias globais (TinyUSB precisa antes de USB.begin)
+BLEConnection bleHost;
 
 void setup() {
     Serial.begin(115200);
-    midiHandler.begin();  // (1)
+    midiHandler.addTransport(&usbHost);   // (2) registra cada transporte
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();                       // (3) o user controla o lifecycle
+    bleHost.begin("ESP32 MIDI BLE");
+    midiHandler.begin();                   // (4)
 }
 
 void loop() {
-    midiHandler.task();   // (2)
+    midiHandler.task();                    // (5)
 
-    for (const auto& ev : midiHandler.getQueue()) {  // (3)
+    for (const auto& ev : midiHandler.getQueue()) {  // (6)
         char noteBuf[8];
         Serial.printf("%-12s %-5s ch=%d  vel=%d\n",
             MIDIHandler::statusName(ev.statusCode),    // "NoteOn" | "NoteOff" | "ControlChange"...
@@ -40,9 +49,12 @@ void loop() {
 
 **Anotações:**
 
-1. `begin()` inicializa automaticamente USB Host (se o chip suportar) e BLE (se habilitado)
-2. `task()` deve ser chamado em todo `loop()` — ele drena os ring buffers de todos os transportes
-3. `getQueue()` retorna a fila de eventos desde a última chamada de `task()`
+1. Em v6+ os transportes (`USBConnection`, `BLEConnection`, `UARTConnection`, etc.) são instanciados explicitamente. Inclua só os headers que vai usar.
+2. `addTransport(&t)` registra cada um no `MIDIHandler` antes do `begin()`.
+3. Cada transporte controla seu próprio `begin()`: `usbHost.begin()` (sem nome), `bleHost.begin("nome")`, `uart.begin(...)`.
+4. `midiHandler.begin()` aplica config e prepara o queue. Não inicia transportes nenhum.
+5. `task()` deve ser chamado em todo `loop()`, drena os ring buffers de todos os transportes registrados.
+6. `getQueue()` retorna a fila de eventos desde a última chamada de `task()`.
 
 ---
 
@@ -111,7 +123,7 @@ for (const auto& ev : midiHandler.getQueue()) {
 
 ## Passo 3 — Enviar MIDI de Volta
 
-Todos os métodos de envio transmitem **simultaneamente** para todos os transportes ativos:
+Os métodos de envio fazem **fan-out**: tentam cada transporte registrado em ordem e retornam `true` no primeiro que aceitar. Não é broadcast simultâneo.
 
 ```cpp
 // NoteOn: canal 1, nota C4 (60), velocidade 100
@@ -159,11 +171,11 @@ void loop() {
 void loop() {
     midiHandler.task();
 
-#if ESP32_HOST_MIDI_HAS_BLE
-    if (midiHandler.isBleConnected()) {
+    // v6.0+: consultar a instância de BLEConnection diretamente.
+    // MIDIHandler::isBleConnected() foi removido junto com o member built-in.
+    if (bleHost.isConnected()) {
         Serial.println("BLE MIDI conectado!");
     }
-#endif
 }
 ```
 
@@ -179,7 +191,12 @@ void loop() {
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>
+#include <BLEConnection.h>
 // Arduino IDE: Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;
+BLEConnection bleHost;
 
 void setup() {
     Serial.begin(115200);
@@ -189,6 +206,10 @@ void setup() {
     MIDIHandlerConfig cfg;
     cfg.maxEvents = 20;         // capacidade da fila
     cfg.chordTimeWindow = 50;   // ms para agrupar acordes
+    midiHandler.addTransport(&usbHost);
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();
+    bleHost.begin("ESP32 MIDI BLE");
     midiHandler.begin(cfg);
 
     Serial.println("Pronto! Conecte um teclado USB ou use BLE.");
@@ -222,7 +243,7 @@ void loop() {
 
 ---
 
-## Fluxo de Inicialização
+## Fluxo de Inicialização (v6.0+)
 
 ```mermaid
 sequenceDiagram
@@ -231,18 +252,21 @@ sequenceDiagram
     participant USB as USBConnection
     participant BLE as BLEConnection
 
-    SKETCH->>HANDLER: midiHandler.begin()
-    HANDLER->>HANDLER: Lê MIDIHandlerConfig
-    HANDLER->>USB: usbTransport.begin()
+    SKETCH->>USB: USBConnection usbHost; (global)
+    SKETCH->>BLE: BLEConnection bleHost; (global)
+    SKETCH->>HANDLER: addTransport(&usbHost)
+    SKETCH->>HANDLER: addTransport(&bleHost)
+    SKETCH->>USB: usbHost.begin()
     Note over USB: Inicia FreeRTOS task\nno Core 0
-    HANDLER->>BLE: bleTransport.begin(bleName)
+    SKETCH->>BLE: bleHost.begin("nome")
     Note over BLE: Inicia stack BLE\ne advertising
+    SKETCH->>HANDLER: midiHandler.begin(cfg)
     HANDLER-->>SKETCH: Pronto
 
     loop Cada loop()
         SKETCH->>HANDLER: midiHandler.task()
-        HANDLER->>USB: usb.task()
-        HANDLER->>BLE: ble.task()
+        HANDLER->>USB: usbHost.task()
+        HANDLER->>BLE: bleHost.task()
         USB-->>HANDLER: Eventos do ring buffer
         BLE-->>HANDLER: Eventos do ring buffer
         HANDLER-->>SKETCH: getQueue() com eventos

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,15 +43,24 @@ flowchart TD
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>   // v6.0+: transportes são explícitos
+#include <BLEConnection.h>
 // Arduino IDE: Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;
+BLEConnection bleHost;
 
 void setup() {
     Serial.begin(115200);
-    midiHandler.begin();  // inicializa USB Host + BLE automaticamente
+    midiHandler.addTransport(&usbHost);  // registre cada transporte que vai usar
+    midiHandler.addTransport(&bleHost);
+    usbHost.begin();                      // user controla cada lifecycle
+    bleHost.begin("Meu Device");
+    midiHandler.begin();
 }
 
 void loop() {
-    midiHandler.task();  // processa todos os transportes
+    midiHandler.task();  // processa todos os transportes registrados
 
     for (const auto& ev : midiHandler.getQueue()) {
         char noteBuf[8];

--- a/docs/transportes/ble-midi.md
+++ b/docs/transportes/ble-midi.md
@@ -21,24 +21,27 @@ O ESP32 se anuncia como um periférico BLE MIDI 1.0. Dispositivos iOS (GarageBan
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <BLEConnection.h>            // v6.0+: BLE é um transporte explícito
+
+BLEConnection bleHost;                // global
 
 void setup() {
     Serial.begin(115200);
 
-    MIDIHandlerConfig cfg;
-    cfg.bleName = "Meu Sintetizador";  // Nome que aparece no iOS/macOS
-    midiHandler.begin(cfg);
+    midiHandler.addTransport(&bleHost);
+    bleHost.begin("Meu Sintetizador");  // nome aparece no iOS/macOS
+    midiHandler.begin();
 
-    // O BLE começa a anunciar automaticamente
     Serial.println("BLE MIDI aguardando conexão...");
 }
 
 void loop() {
     midiHandler.task();
 
-#if ESP32_HOST_MIDI_HAS_BLE
     static bool wasConnected = false;
-    bool connected = midiHandler.isBleConnected();
+    // v6.0+: consultar diretamente a instância do BLEConnection
+    // (MIDIHandler::isBleConnected foi removido com o member built-in)
+    bool connected = bleHost.isConnected();
 
     if (connected && !wasConnected) {
         Serial.println("✅ BLE MIDI conectado!");
@@ -46,7 +49,6 @@ void loop() {
         Serial.println("❌ BLE MIDI desconectado.");
     }
     wasConnected = connected;
-#endif
 
     for (const auto& ev : midiHandler.getQueue()) {
         char noteBuf[8];
@@ -103,19 +105,20 @@ sequenceDiagram
 
 ## Enviar MIDI via BLE
 
-O BLE MIDI suporta envio completo. Quando você chama `sendNoteOn()`, o dado é enviado via BLE NOTIFY para o dispositivo conectado:
+O BLE MIDI suporta envio completo. Quando você chama `sendNoteOn()`, o handler tenta cada transporte registrado em ordem (fan-out) e retorna `true` no primeiro que aceitar. Se BLE for o primeiro registrado e estiver conectado, vai por ele:
 
 ```cpp
-// Envia para TODOS os transportes (incluindo BLE)
 midiHandler.sendNoteOn(1, 60, 100);   // canal 1, C4, vel 100
 midiHandler.sendNoteOff(1, 60, 0);    // libera C4
 midiHandler.sendControlChange(1, 7, 127);  // volume máximo
-midiHandler.sendPitchBend(1, 0);      // centro (8192 no raw)
+midiHandler.sendPitchBend(1, 0);      // centro (0 na API, 8192 no raw)
 
-// Envio raw BLE (legado — use sendRaw() preferencialmente)
+// Envio raw BLE (legado, use sendRaw() preferencialmente)
 uint8_t msg[] = {0x90, 0x3C, 0x64};  // NoteOn C4 vel=100
 midiHandler.sendBleRaw(msg, 3);
 ```
+
+> Para forçar envio direto via BLE sem o fan-out do handler, chame `bleHost.sendMidiMessage(msg, len)`.
 
 ---
 
@@ -127,15 +130,12 @@ midiHandler.sendBleRaw(msg, 3);
 void loop() {
     midiHandler.task();
 
-#if ESP32_HOST_MIDI_HAS_BLE
-    if (midiHandler.isBleConnected()) {
-        // Enviar apenas se BLE estiver conectado
+    if (bleHost.isConnected()) {     // v6.0+: consulte a instância
         midiHandler.sendNoteOn(1, 60, 100);
         delay(500);
         midiHandler.sendNoteOff(1, 60, 0);
         delay(500);
     }
-#endif
 }
 ```
 

--- a/docs/transportes/esp-now.md
+++ b/docs/transportes/esp-now.md
@@ -153,18 +153,23 @@ sequenceDiagram
 ```cpp
 #include <ESP32_Host_MIDI.h>
 #include "src/ESPNowConnection.h"
+#include <USBConnection.h>     // v6.0+: cada transport explícito
+#include <BLEConnection.h>
 
+USBConnection    usbHost;
+BLEConnection    bleHost;
 ESPNowConnection espNow;
 
 void setup() {
-    // ESP-NOW
-    espNow.begin(11);
+    midiHandler.addTransport(&usbHost);
+    midiHandler.addTransport(&bleHost);
     midiHandler.addTransport(&espNow);
 
-    // USB Host + BLE iniciados automaticamente
-    MIDIHandlerConfig cfg;
-    cfg.bleName = "Jam Node";
-    midiHandler.begin(cfg);
+    usbHost.begin();
+    bleHost.begin("Jam Node");
+    espNow.begin(11);
+
+    midiHandler.begin();
 
     // Agora teclado USB + BLE + ESP-NOW estão todos ativos!
 }

--- a/docs/transportes/usb-device.md
+++ b/docs/transportes/usb-device.md
@@ -111,18 +111,19 @@ flowchart LR
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <BLEConnection.h>            // v6.0+: BLE explícito
 #include "src/USBDeviceConnection.h"
 // Tools > USB Mode → "USB-OTG (TinyUSB)"
 
 USBDeviceConnection usbMIDI("BLE-USB Bridge");
+BLEConnection       bleHost;
 
 void setup() {
     midiHandler.addTransport(&usbMIDI);
+    midiHandler.addTransport(&bleHost);
     usbMIDI.begin();
-
-    MIDIHandlerConfig cfg;
-    cfg.bleName = "Bridge MIDI";
-    midiHandler.begin(cfg);
+    bleHost.begin("Bridge MIDI");      // nome BLE direto no transport
+    midiHandler.begin();
 
     // Pronto! Qualquer MIDI de BLE vai para USB e vice-versa
 }

--- a/docs/transportes/usb-host.md
+++ b/docs/transportes/usb-host.md
@@ -45,11 +45,16 @@ Tools → USB Mode → "USB Host"
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
+#include <USBConnection.h>      // v6.0+: USB Host é um transporte explícito
 // Tools > USB Mode → "USB Host"
+
+USBConnection usbHost;          // global
 
 void setup() {
     Serial.begin(115200);
-    midiHandler.begin();  // USB Host iniciado automaticamente
+    midiHandler.addTransport(&usbHost);  // registra antes de begin()
+    usbHost.begin();                      // inicia stack USB Host
+    midiHandler.begin();
 }
 
 void loop() {
@@ -66,7 +71,7 @@ void loop() {
 }
 ```
 
-Nenhuma configuração adicional é necessária — o transporte USB é built-in.
+Em v5 o `MIDIHandler::begin()` instanciava `USBConnection` automaticamente. Em v6+ todo transporte é explícito; veja [Migration Guide](../migration-v6.md).
 
 ---
 

--- a/docs/transportes/visao-geral.md
+++ b/docs/transportes/visao-geral.md
@@ -20,77 +20,69 @@ A biblioteca suporta **9 transportes MIDI simultâneos**. Cada um implementa a m
 
 ---
 
-## Transportes Built-in vs. Externos
+## Padrão de uso (v6.0+: todo transporte é explícito)
 
 ```mermaid
 graph LR
-    subgraph BUILTIN["✅ Built-in — registrados automaticamente"]
-        USB["🔌 USB Host\n(ESP32-S3/S2/P4)"]
-        BLE["📱 BLE MIDI\n(ESP32 com Bluetooth)"]
-        ESPNOW["📡 ESP-NOW\n(qualquer ESP32)"]
-    end
-
-    subgraph EXTERNAL["📦 Externos — incluir manualmente"]
+    subgraph TRANSPORTS["📦 Transports — cada um instanciado pelo user"]
+        USB["🔌 USBConnection"]
+        USB2["🎵 USBMIDI2Connection"]
+        BLE["📱 BLEConnection"]
+        USBDEV["💻 USBDeviceConnection"]
         UART["🎹 UARTConnection"]
+        ESPNOW["📡 ESPNowConnection"]
         RTP["🌐 RTPMIDIConnection"]
         ETH["🔗 EthernetMIDIConnection"]
         OSC["🎨 OSCConnection"]
-        USBDEV["💻 USBDeviceConnection"]
     end
 
-    BUILTIN --> HANDLER["MIDIHandler\nmidiHandler.begin()"]
-    EXTERNAL --> ADD["midiHandler.addTransport()"]
-    ADD --> HANDLER
+    TRANSPORTS --> ADD["midiHandler.addTransport(&transport)"]
+    ADD --> HANDLER["MIDIHandler"]
 
-    style BUILTIN fill:#1B5E20,color:#fff,stroke:#2E7D32
-    style EXTERNAL fill:#1A237E,color:#fff,stroke:#283593
+    style TRANSPORTS fill:#1A237E,color:#fff,stroke:#283593
     style HANDLER fill:#3F51B5,color:#fff,stroke:#283593
 ```
 
-### Transportes Built-in
+Em v5 o `MIDIHandler::begin()` instanciava automaticamente `USBConnection` e `BLEConnection` quando o chip suportava. Em v6+ todo transporte é explícito: o user inclui o header, instancia globalmente, registra via `addTransport()`, e chama `transport.begin()`. Isso reduz acoplamento e faz o código pagar só pelo que usa.
 
-Registrados automaticamente quando o chip suporta:
-
-```cpp
-#include <ESP32_Host_MIDI.h>
-
-void setup() {
-    midiHandler.begin();  // USB + BLE + ESP-NOW iniciados automaticamente
-}
-```
-
-### Transportes Externos
-
-Devem ser incluídos e registrados manualmente:
+### Padrão completo
 
 ```cpp
 #include <ESP32_Host_MIDI.h>
-#include "src/UARTConnection.h"     // DIN-5 MIDI serial
-#include "src/RTPMIDIConnection.h"  // Apple MIDI via WiFi
-#include "src/OSCConnection.h"      // OSC via WiFi
+#include <USBConnection.h>          // inclua só os transports que vai usar
+#include <BLEConnection.h>
+#include <UARTConnection.h>
+#include <RTPMIDIConnection.h>
+#include <OSCConnection.h>
 
-UARTConnection uartMIDI;
+USBConnection     usbHost;
+BLEConnection     bleHost;
+UARTConnection    uartMIDI;
 RTPMIDIConnection rtpMIDI;
-OSCConnection oscMIDI;
+OSCConnection     oscMIDI;
 
 void setup() {
-    // 1. Inicializar transportes externos
-    uartMIDI.begin(Serial1, 16, 17);
-    rtpMIDI.begin("Meu ESP32");
-    oscMIDI.begin(8000, IPAddress(192,168,1,100), 9000);
-
-    // 2. Registrar no handler
+    // 1. Registre cada transport
+    midiHandler.addTransport(&usbHost);
+    midiHandler.addTransport(&bleHost);
     midiHandler.addTransport(&uartMIDI);
     midiHandler.addTransport(&rtpMIDI);
     midiHandler.addTransport(&oscMIDI);
 
-    // 3. Iniciar o handler
+    // 2. Cada transport inicia seu próprio stack
+    usbHost.begin();
+    bleHost.begin("Meu ESP32");
+    uartMIDI.begin(Serial1, 16, 17);
+    rtpMIDI.begin("Meu ESP32");
+    oscMIDI.begin(8000, IPAddress(192,168,1,100), 9000);
+
+    // 3. Inicia o handler (queue, dispatch, chord detection, etc.)
     midiHandler.begin();
 }
 ```
 
-!!! warning "Limite de transportes"
-    O `MIDIHandler` suporta até **4 transportes externos** via `addTransport()`. Os transportes built-in (USB, BLE, ESP-NOW) não contam neste limite.
+!!! warning "Limite de transports"
+    O `MIDIHandler` suporta até **4 transports** registrados via `addTransport()`. Em v6+ não há built-ins (todos contam).
 
 ---
 
@@ -197,8 +189,8 @@ public:
 MyTransport myTransport;
 
 void setup() {
+    midiHandler.addTransport(&myTransport);   // registre antes de begin()
     myTransport.begin();
-    midiHandler.addTransport(&myTransport);
     midiHandler.begin();
 }
 ```


### PR DESCRIPTION
## Summary

The v6.0.0 release shipped the lib correctly but several Markdown docs still described the v5 auto-start contract or referenced API that never existed in `MIDIHandler`. This PR updates 19 doc files to reflect the actual v6 surface.

## Fixes per category

- **Auto-start narrative**: `midiHandler.begin()` no longer auto-instantiates USBConnection / BLEConnection. Every doc snippet now declares transports globally, registers via `addTransport`, and calls each transport's own `begin()`.
- **MIDIHandlerConfig**: removed references to non-existent `enableHistory` and `chordDetection` boolean fields. Real fields are `historyCapacity` (int) and `chordTimeWindow` (ms). `bleName` clarified as v5 legacy (kept for binary compat, not consumed by handler in v6).
- **Send semantics**: corrected "broadcast to ALL transports" wording to fan-out (returns true on first transport that accepts).
- **Removed APIs**: dropped `midiHandler.isBleConnected()` calls (use `bleHost.isConnected()`). Dropped `midiHandler.getChordName()` references (the method belongs to GingoAdapter, never to MIDIHandler).
- **Pitch bend ranges**: `sendPitchBend(ch, val)` takes signed -8192..+8191 (center 0), not 0..16383.

## Files touched

19 docs across `README.md`, `README-PT-BR.md`, `docs/index.md`, `docs/api/`, `docs/guia/`, `docs/transportes/`, `docs/funcionalidades/`, `docs/exemplos/`, `docs/avancado/`.

## Test plan

- [x] Grep sweep confirms zero remaining stale calls
- [x] Every doc calling `midiHandler.begin()` also documents `addTransport()`
- [x] Em-dash sweep on diff is empty
- [ ] CI Native + Arduino compile-sketches green (gated on this PR)